### PR TITLE
feat: Adds roles to service account

### DIFF
--- a/examples/public-dns-with-cloud-dns/main.tf
+++ b/examples/public-dns-with-cloud-dns/main.tf
@@ -72,6 +72,7 @@ resource "kubernetes_manifest" "managed_certificate" {
       domains = [module.wandb_infra.fqdn]
     }
   }
+  depends_on = [module.wandb_app]
 }
 
 # Create Loadbalancer
@@ -91,6 +92,7 @@ resource "kubernetes_ingress" "ingress" {
       service_port = 8080
     }
   }
+   depends_on = [module.wandb_app]
 }
 
 output "url" {

--- a/examples/public-dns-with-cloud-dns/variables.tf
+++ b/examples/public-dns-with-cloud-dns/variables.tf
@@ -13,7 +13,6 @@ variable "zone" {
   description = "Google zone"
 }
 
-
 variable "namespace" {
   type        = string
   description = "Namespace prefix used for resources"

--- a/modules/file_storage/main.tf
+++ b/modules/file_storage/main.tf
@@ -32,18 +32,17 @@ resource "google_pubsub_topic" "file_storage" {
   name = "${var.namespace}-file-storage"
 }
 
-# resource "google_pubsub_topic_iam_member" "file_storage_editor" {
-#   topic  = google_pubsub_topic.file_storage.name
-#   member = local.sa_member
-#   role   = "roles/editor"
-# }
+resource "google_pubsub_topic_iam_member" "file_storage_editor" {
+  topic  = google_pubsub_topic.file_storage.name
+  member = local.sa_member
+  role   = "roles/editor"
+}
 
 resource "google_pubsub_subscription" "file_storage" {
   name                 = "${var.namespace}-file-storage"
   topic                = google_pubsub_topic.file_storage.name
   ack_deadline_seconds = 30
 }
-
 
 # Enable notifications by giving the correct IAM permission to the unique
 # service account.

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -35,19 +35,11 @@ resource "google_project_iam_member" "token_creator" {
 
 # PubSub Admin role provides service account members 
 # full access to topics and subscriptions
-resource "google_project_iam_member" "pubsub_admin" {
-  project = local.project_id
-  role    = "roles/pubsub.admin"
-  member  = local.sa_member
-}
-
-# Storage Object Admin role grants service account members
-# full control of objects in a storage bucket
-resource "google_project_iam_member" "storage_object_admin" {
-  project = local.project_id
-  role    = "roles/storage.objectAdmin"
-  member  = local.sa_member
-}
+# resource "google_project_iam_member" "pubsub_admin" {
+#   project = local.project_id
+#   role    = "roles/pubsub.admin"
+#   member  = local.sa_member
+# }
 
 # Cloud SQL Client role allows service account members
 # connectivity access to Cloud SQL instances

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -1,3 +1,5 @@
+data "google_client_config" "current" {}
+
 resource "random_id" "main" {
   # 30 bytes ensures that enough characters are generated to satisfy the service account ID requirements, regardless of
   # the prefix.
@@ -12,17 +14,45 @@ resource "google_service_account" "main" {
   description  = "Service Account used by Weights & Biases."
 }
 
+# Creates a managed service account key (credentials key)
 resource "google_service_account_key" "main" {
   service_account_id = google_service_account.main.name
 }
 
-resource "google_project_iam_binding" "token_creator_binding" {
-  project = "your-project-id" // project_id is null as part of the root main.tf
-  role    = [
-  "roles/iam.serviceAccountTokenCreator",
-  "roles/pubsub.admin",
-  "roles/composer.environmentAndStorageObjectAdmin",
-  "roles/cloudsql.client"
-] 
-  members = "serviceAccount:${google_service_account.sa-name.email}"
+locals {
+  sa_member  = "serviceAccount:${google_service_account.main.email}"
+  project_id = data.google_client_config.current.project
+}
+
+# Service Account Token Creator role allows principals to impersonate
+# service accounts to create OAuth 2.0 tokens which can be used to
+# authenticate with Google APIs 
+resource "google_project_iam_member" "token_creator" {
+  project = local.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = local.sa_member
+}
+
+# PubSub Admin role provides service account members 
+# full access to topics and subscriptions
+resource "google_project_iam_member" "pubsub_admin" {
+  project = local.project_id
+  role    = "roles/pubsub.admin"
+  member  = local.sa_member
+}
+
+# Storage Object Admin role grants service account members
+# full control of objects in a storage bucket
+resource "google_project_iam_member" "storage_object_admin" {
+  project = local.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = local.sa_member
+}
+
+# Cloud SQL Client role allows service account members
+# connectivity access to Cloud SQL instances
+resource "google_project_iam_member" "cloudsql_client" {
+  project = local.project_id
+  role    = "roles/cloudsql.client"
+  member  = local.sa_member
 }

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -15,3 +15,14 @@ resource "google_service_account" "main" {
 resource "google_service_account_key" "main" {
   service_account_id = google_service_account.main.name
 }
+
+resource "google_project_iam_binding" "token_creator_binding" {
+  project = "your-project-id" // project_id is null as part of the root main.tf
+  role    = [
+  "roles/iam.serviceAccountTokenCreator",
+  "roles/pubsub.admin",
+  "roles/composer.environmentAndStorageObjectAdmin",
+  "roles/cloudsql.client"
+] 
+  members = "serviceAccount:${google_service_account.sa-name.email}"
+}

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -33,14 +33,6 @@ resource "google_project_iam_member" "token_creator" {
   member  = local.sa_member
 }
 
-# PubSub Admin role provides service account members 
-# full access to topics and subscriptions
-# resource "google_project_iam_member" "pubsub_admin" {
-#   project = local.project_id
-#   role    = "roles/pubsub.admin"
-#   member  = local.sa_member
-# }
-
 # Cloud SQL Client role allows service account members
 # connectivity access to Cloud SQL instances
 resource "google_project_iam_member" "cloudsql_client" {


### PR DESCRIPTION
- This PR enables roles for service account so that W&B has the right role permissions for the instance
- Tested by creating a deployment using this terraform and running `wandb verify` to verify role propagation.