### PR TITLE
Pass redis certificate and auth string to wandb

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,8 @@ module "redis" {
 }
 
 locals {
-  redis_connection_string = var.create_redis ? "redis://${module.redis.0.connection_string}?tls=true&ttlInSeconds=60" : null
+  redis_certificate       = var.create_redis ? module.redis.0.ca_cert : null
+  redis_connection_string = var.create_redis ? "redis://:${module.redis.0.auth_string}@${module.redis.0.connection_string}?tls=true&ttlInSeconds=60&caCertPath=/tmp/server_ca.pem" : null
   bucket                  = local.create_bucket ? module.storage.0.bucket_name : var.bucket_name
   bucket_queue            = var.use_internal_queue ? "internal://" : "pubsub:/${module.storage.0.bucket_queue_name}"
 }
@@ -120,7 +121,7 @@ module "gke_app" {
   bucket_queue               = local.bucket_queue
   database_connection_string = "mysql://${module.database.connection_string}"
   redis_connection_string    = local.redis_connection_string
-
+  redis_certificate          = local.redis_certificate
 
   oidc_client_id   = var.oidc_client_id
   oidc_issuer      = var.oidc_issuer

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -18,5 +18,7 @@ resource "google_redis_instance" "default" {
   transit_encryption_mode = "SERVER_AUTHENTICATION"
   connect_mode            = "DIRECT_PEERING"
 
+  auth_enabled = true
+
   labels = var.labels
 }

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,3 +1,12 @@
 output "connection_string" {
   value = "${google_redis_instance.default.host}:${google_redis_instance.default.port}"
 }
+
+output "ca_cert" {
+  value = "${google_redis_instance.default.server_ca_certs[0].cert}"
+}
+
+output "auth_string" {
+  value = "${google_redis_instance.default.auth_string}"
+}
+


### PR DESCRIPTION
Google Memorystore requires us to install a certificate authority on the client. Also enabling auth here and passing that to the client as well.

See related prs: 

https://github.com/wandb/core/pull/9453
https://github.com/wandb/core/pull/9453