### PR TITLE
fix: Explicitly disable client certificate auth (deprecated by kubernetes)

### DIFF
--- a/modules/app_gke/main.tf
+++ b/modules/app_gke/main.tf
@@ -22,6 +22,15 @@ resource "google_container_cluster" "default" {
   # node pool and immediately delete it.
   remove_default_node_pool = true
   initial_node_count       = 1
+
+  # Disable client certificate authentication, which reduces the attack surface 
+  # for the cluster by disabling this deprecated feature. It defaults to false, 
+  # but this will make it explicit and quiet some security tooling.
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
 }
 
 resource "random_pet" "node_pool" {


### PR DESCRIPTION
Disable client certificate authentication, which in general reduces the attack surface for the cluster by disabling this deprecated feature. It defaults to false anyway (i.e. this is already the current setting in our cluster), but this will make it explicit and quiet some security tooling.

Tested on a new install and an existing install.