### PR TITLE
feat: Add disable legacy endpoints

### DIFF
--- a/modules/app_gke/main.tf
+++ b/modules/app_gke/main.tf
@@ -63,6 +63,10 @@ resource "google_container_node_pool" "default" {
     shielded_instance_config {
       enable_secure_boot = true
     }
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
   }
 
   management {

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -68,10 +68,6 @@ resource "google_sql_database_instance" "default" {
       name  = "max_execution_time"
       value = 60000
     }
-    database_flags {
-      name  = "sort_buffer_size"
-      value = 1048576
-    }
   }
 }
 

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -68,6 +68,10 @@ resource "google_sql_database_instance" "default" {
       name  = "max_execution_time"
       value = 60000
     }
+    database_flags {
+      name  = "sort_buffer_size"
+      value = 1048576
+    }
   }
 }
 


### PR DESCRIPTION
Once the cluster is created with a default node pool and if we run a terraform apply after, it results in a forced replacement of the default node pool as it interprets the metadata for the node config specifically `disable-legacy-endpoints` has changed. Explicitly adding this metadata to the node config resolves the error.

More info:
https://github.com/hashicorp/terraform-provider-google/issues/3230
https://github.com/hashicorp/terraform-provider-google/issues/2626