### PR TITLE
fix: Fix binary authorization deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ resources that lack official modules.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.15 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.39 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.9 |
 
 ## Providers

--- a/modules/app_gke/main.tf
+++ b/modules/app_gke/main.tf
@@ -6,7 +6,9 @@ resource "google_container_cluster" "default" {
   networking_mode = "VPC_NATIVE"
 
   enable_intranode_visibility = true
-  enable_binary_authorization = true
+  binary_authorization {
+    evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE" 
+  }
 
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = "/14"

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.15"
+      version = "~> 4.39"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Once the [enable_binary_authorization](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#enable_binary_authorization) is deprecated the following warning is issued during the `terraform plan`.

```
╷
│ Warning: Argument is deprecated
│
│   with module.wandb.module.app_gke.google_container_cluster.default,
│   on .terraform/modules/wandb/modules/app_gke/main.tf line 9, in resource "google_container_cluster" "default":
│    9:   enable_binary_authorization = true
│
│ Deprecated in favor of binary_authorization.
│
│ (and one more similar warning elsewhere)
╵
```

To fix the warning the new [binary_authorization block](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_binary_authorization) to supply the same functionality of `enable_binary_authorization`