### PR TITLE
fix: Allow more than 10 inbound CIDRs

### DIFF
--- a/modules/app_lb/url_map/main.tf
+++ b/modules/app_lb/url_map/main.tf
@@ -53,16 +53,19 @@ resource "google_compute_security_policy" "default" {
     description = "Deny access to all IPs"
   }
 
-  rule {
-    action   = "allow"
-    priority = 1
-    match {
-      versioned_expr = "SRC_IPS_V1"
-      config {
-        src_ip_ranges = var.allowed_inbound_cidr
+  dynamic "rule" {
+    for_each = chunklist(var.allowed_inbound_cidr, 10)
+    content {
+      action   = "allow"
+      priority = 1 + rule.key # Index
+      match {
+        versioned_expr = "SRC_IPS_V1"
+        config {
+          src_ip_ranges = rule.value
+        }
       }
+      description = "allow list rule"
     }
-    description = "allow list rule"
   }
 }
 


### PR DESCRIPTION
Cloud Armor rules have a limit of 10 CIDRs per rule. This is a problem when trying to add more than 10 remote workers to the modules allow list.

Convert the rule to a dynamic rule to allow any number of inbound CIDRs and increment the rule priority with the index.