### PR TITLE
fix: Update mysql version

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ No resources.
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |
 | <a name="input_database_sort_buffer_size"></a> [database\_sort\_buffer\_size](#input\_database\_sort\_buffer\_size) | Specifies the sort\_buffer\_size value to set for the database | `number` | `262144` | no |
-| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Version for MySQL | `string` | `"MYSQL_8_0_29"` | no |
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Version for MySQL | `string` | `"MYSQL_8_0_31"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the instance should have deletion protection enabled. The database / Bucket can't be deleted when this value is set to `true`. | `bool` | `true` | no |
 | <a name="input_disable_code_saving"></a> [disable\_code\_saving](#input\_disable\_code\_saving) | Boolean indicating if code saving is disabled | `bool` | `false` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain for accessing the Weights & Biases UI. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ No resources.
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |
 | <a name="input_database_sort_buffer_size"></a> [database\_sort\_buffer\_size](#input\_database\_sort\_buffer\_size) | Specifies the sort\_buffer\_size value to set for the database | `number` | `262144` | no |
-| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Version for MySQL | `string` | `"MYSQL_8_0_31"` | no |
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Version for MySQL | `string` | n/a | yes |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the instance should have deletion protection enabled. The database / Bucket can't be deleted when this value is set to `true`. | `bool` | `true` | no |
 | <a name="input_disable_code_saving"></a> [disable\_code\_saving](#input\_disable\_code\_saving) | Boolean indicating if code saving is disabled | `bool` | `false` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain for accessing the Weights & Biases UI. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -147,7 +147,7 @@ module "gke_app" {
   oidc_auth_method = var.oidc_auth_method
   oidc_secret      = var.oidc_secret
   local_restore    = var.local_restore
-  other_wandb_env  = {
+  other_wandb_env = {
     "GORILLA_DISABLE_CODE_SAVING" = var.disable_code_saving
   }
 

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -60,7 +60,7 @@ variable "database_version" {
   default     = "MYSQL_8_0_31"
 
   validation {
-    condition     = contains(["MYSQL_5_7", "MYSQL_8_0", "MYSQL_8_0_28", "MYSQL_8_0_29", "MYSQL_8_0_30", "MYSQL_8_0_31"], var.database_version)
+    condition     = regex("MYSQL_(8_0(_[0-9]*)?|5_7)$", var.database_version)
     error_message = "We only support MySQL: \"MYSQL_5_7\"; \"MYSQL_8_0\"."
   }
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -57,10 +57,10 @@ variable "labels" {
 variable "database_version" {
   description = "Version for MySQL"
   type        = string
-  default     = "MYSQL_8_0_28"
+  default     = "MYSQL_8_0_30"
 
   validation {
-    condition     = contains(["MYSQL_5_7", "MYSQL_8_0", "MYSQL_8_0_28", "MYSQL_8_0_29"], var.database_version)
+    condition     = contains(["MYSQL_5_7", "MYSQL_8_0", "MYSQL_8_0_28", "MYSQL_8_0_30"], var.database_version)
     error_message = "We only support MySQL: \"MYSQL_5_7\"; \"MYSQL_8_0\"."
   }
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -57,10 +57,9 @@ variable "labels" {
 variable "database_version" {
   description = "Version for MySQL"
   type        = string
-  default     = "MYSQL_8_0_31"
 
   validation {
-    condition     = regex("MYSQL_(8_0(_[0-9]*)?|5_7)$", var.database_version)
+    condition     = regex("^MYSQL_(8_0(_[0-9]*)?|5_7)$", var.database_version)
     error_message = "We only support MySQL: \"MYSQL_5_7\"; \"MYSQL_8_0\"."
   }
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -57,7 +57,7 @@ variable "labels" {
 variable "database_version" {
   description = "Version for MySQL"
   type        = string
-  default     = "MYSQL_8_0_30"
+  default     = "MYSQL_8_0_31"
 
   validation {
     condition     = contains(["MYSQL_5_7", "MYSQL_8_0", "MYSQL_8_0_28", "MYSQL_8_0_29", "MYSQL_8_0_30", "MYSQL_8_0_31"], var.database_version)

--- a/variables.tf
+++ b/variables.tf
@@ -131,7 +131,6 @@ variable "ssl" {
 variable "database_version" {
   description = "Version for MySQL"
   type        = string
-  default     = "MYSQL_8_0_31"
 }
 
 variable "database_machine_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -131,7 +131,7 @@ variable "ssl" {
 variable "database_version" {
   description = "Version for MySQL"
   type        = string
-  default     = "MYSQL_8_0_30"
+  default     = "MYSQL_8_0_31"
 }
 
 variable "database_machine_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -131,7 +131,7 @@ variable "ssl" {
 variable "database_version" {
   description = "Version for MySQL"
   type        = string
-  default     = "MYSQL_8_0_29"
+  default     = "MYSQL_8_0_30"
 }
 
 variable "database_machine_type" {


### PR DESCRIPTION
The module defaults the MySQL version to the `8_0_29`, which is not supported by GCP anymore, and during the deployment, the following error comes up.

```
│ Error: Error, failed to create instance tf-perms-gcp-actual-mastiff: googleapi: Error 400: Invalid request: Database version (MYSQL_8_0_29) is deprecated.., invalid
```
The current default version for the `8_0` is the `0_0_26`.

https://cloud.google.com/sql/docs/mysql/db-versions

The idea is to test and validate the downtime time to upgrade the DB for the next minor version, `8_0_30`, considering that it will cause downtime according to the documentation.

https://cloud.google.com/sql/docs/mysql/upgrade-minor-db-version#minor-ver-upgrade

`the instance is restarted during the operation, which causes downtime.`

From Terraform perspective, this is a change in place, but there's downtime as stated in the documentation.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.wandb.module.database.google_sql_database_instance.default will be updated in-place
  ~ resource "google_sql_database_instance" "default" {
      ~ database_version               = "MYSQL_8_0_28" -> "MYSQL_8_0_30"
        id                             = "tf-perms-gcp-novel-hound"
        name                           = "tf-perms-gcp-novel-hound"
        # (13 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
