### PR TITLE
fix: Update GKE version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,7 @@ module "app_gke" {
   subnetwork      = local.subnetwork
   service_account = module.service_accounts.service_account
   depends_on      = [module.project_factory_project_services]
+  gke_version     = var.gke_cluster_version
 }
 
 
@@ -131,7 +132,7 @@ locals {
 
 module "gke_app" {
   source  = "wandb/wandb/kubernetes"
-  version = "1.4.1"
+  version = "1.6.0"
 
   license = var.license
 
@@ -147,7 +148,7 @@ module "gke_app" {
   oidc_auth_method = var.oidc_auth_method
   oidc_secret      = var.oidc_secret
   local_restore    = var.local_restore
-  other_wandb_env  = {
+  other_wandb_env = {
     "GORILLA_DISABLE_CODE_SAVING" = var.disable_code_saving
   }
 

--- a/modules/app_gke/main.tf
+++ b/modules/app_gke/main.tf
@@ -1,9 +1,10 @@
 resource "google_container_cluster" "default" {
   name = "${var.namespace}-cluster"
 
-  network         = var.network.self_link
-  subnetwork      = var.subnetwork.self_link
-  networking_mode = "VPC_NATIVE"
+  network            = var.network.self_link
+  subnetwork         = var.subnetwork.self_link
+  networking_mode    = "VPC_NATIVE"
+  min_master_version = var.gke_version
 
   enable_intranode_visibility = true
 
@@ -47,6 +48,7 @@ resource "google_container_node_pool" "default" {
   name       = "default-pool-${random_pet.node_pool.id}"
   cluster    = google_container_cluster.default.id
   node_count = 2
+  version    = var.gke_version
 
   node_config {
     image_type      = "COS_CONTAINERD"

--- a/modules/app_gke/variables.tf
+++ b/modules/app_gke/variables.tf
@@ -22,3 +22,14 @@ variable "machine_type" {
   type    = string
   default = "n1-standard-4"
 }
+
+variable "gke_version" {
+  description = "Default GKE version"
+  type        = string
+  default     = "1.22.12-gke.500"
+
+  validation {
+    condition     = regex("^1.2[2-4].*", var.gke_version)
+    error_message = "We only support GKE: \"1.22\", \"1.23\" or \"1.24\"."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,13 @@ variable "gke_machine_type" {
   default     = "n1-standard-4"
 }
 
+variable "gke_cluster_version" {
+  description = "Kuberntes version"
+  type        = string
+  default     = "1.22.16-gke.2000"
+
+}
+
 ##########################################
 # Networking                             #
 ##########################################


### PR DESCRIPTION
This PR is intended to upgrade the Kubernetes cluster to a newer stable version since the current version is not supported anymore.

```
module.wandb.module.database.google_sql_user.wandb: Creation complete after 1s [id=wandb//tf-perms-gcp-star-sheep]
╷
│ Error: googleapi: Error 400: Master version "1.22.12-gke.500" is unsupported., badRequest
│
│   with module.wandb.module.app_gke.google_container_cluster.default,
│   on ../terraform-google-wandb/modules/app_gke/main.tf line 1, in resource "google_container_cluster" "default":
│    1: resource "google_container_cluster" "default" {
│
╵
```

It also adds the possibility of informing the Kubernetes version and a validation of the versions accepted.