### PR TITLE
chore: Enable MySQL connection ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ No providers.
 | <a name="module_app_gke"></a> [app\_gke](#module\_app\_gke) | ./modules/app_gke | n/a |
 | <a name="module_app_lb"></a> [app\_lb](#module\_app\_lb) | ./modules/app_lb | n/a |
 | <a name="module_database"></a> [database](#module\_database) | ./modules/database | n/a |
-| <a name="module_gke_app"></a> [gke\_app](#module\_gke\_app) | wandb/wandb/kubernetes | 1.4.1 |
+| <a name="module_gke_app"></a> [gke\_app](#module\_gke\_app) | ../terraform-kubernetes-wandb | n/a |
 | <a name="module_kms"></a> [kms](#module\_kms) | ./modules/kms | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
 | <a name="module_project_factory_project_services"></a> [project\_factory\_project\_services](#module\_project\_factory\_project\_services) | terraform-google-modules/project-factory/google//modules/project_services | ~> 13.0 |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ No resources.
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the instance should have deletion protection enabled. The database / Bucket can't be deleted when this value is set to `true`. | `bool` | `true` | no |
 | <a name="input_disable_code_saving"></a> [disable\_code\_saving](#input\_disable\_code\_saving) | Boolean indicating if code saving is disabled | `bool` | `false` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain for accessing the Weights & Biases UI. | `string` | `null` | no |
-| <a name="input_force_ssl"></a> [force\_ssl](#input\_force\_ssl) | Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string | `bool` | `false` | no |
+| <a name="input_force_ssl"></a> [force\_ssl](#input\_force\_ssl) | Enforce SSL through the usage of the Cloud SQL Proxy (cloudsql://) in the DB connection string | `bool` | `false` | no |
 | <a name="input_gke_machine_type"></a> [gke\_machine\_type](#input\_gke\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"n1-standard-4"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to resources | `map(string)` | `{}` | no |
 | <a name="input_license"></a> [license](#input\_license) | Your wandb/local license | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ No resources.
 | <a name="input_allowed_inbound_cidr"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | (Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
+| <a name="input_database_connection_ssl"></a> [database\_connection\_ssl](#input\_database\_connection\_ssl) | Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |
 | <a name="input_database_sort_buffer_size"></a> [database\_sort\_buffer\_size](#input\_database\_sort\_buffer\_size) | Specifies the sort\_buffer\_size value to set for the database | `number` | `262144` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Version for MySQL | `string` | `"MYSQL_8_0_31"` | no |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ No providers.
 | <a name="module_app_gke"></a> [app\_gke](#module\_app\_gke) | ./modules/app_gke | n/a |
 | <a name="module_app_lb"></a> [app\_lb](#module\_app\_lb) | ./modules/app_lb | n/a |
 | <a name="module_database"></a> [database](#module\_database) | ./modules/database | n/a |
-| <a name="module_gke_app"></a> [gke\_app](#module\_gke\_app) | ../terraform-kubernetes-wandb | n/a |
+| <a name="module_gke_app"></a> [gke\_app](#module\_gke\_app) | github.com/wandb/terraform-kubernetes-wandb | recreate_pod_with_new_db_connection_string |
 | <a name="module_kms"></a> [kms](#module\_kms) | ./modules/kms | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
 | <a name="module_project_factory_project_services"></a> [project\_factory\_project\_services](#module\_project\_factory\_project\_services) | terraform-google-modules/project-factory/google//modules/project_services | ~> 13.0 |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ No providers.
 | <a name="module_app_gke"></a> [app\_gke](#module\_app\_gke) | ./modules/app_gke | n/a |
 | <a name="module_app_lb"></a> [app\_lb](#module\_app\_lb) | ./modules/app_lb | n/a |
 | <a name="module_database"></a> [database](#module\_database) | ./modules/database | n/a |
-| <a name="module_gke_app"></a> [gke\_app](#module\_gke\_app) | github.com/wandb/terraform-kubernetes-wandb | recreate_pod_with_new_db_connection_string |
+| <a name="module_gke_app"></a> [gke\_app](#module\_gke\_app) | wandb/wandb/kubernetes | 1.6.0 |
 | <a name="module_kms"></a> [kms](#module\_kms) | ./modules/kms | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
 | <a name="module_project_factory_project_services"></a> [project\_factory\_project\_services](#module\_project\_factory\_project\_services) | terraform-google-modules/project-factory/google//modules/project_services | ~> 13.0 |
@@ -94,13 +94,13 @@ No resources.
 | <a name="input_allowed_inbound_cidr"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | (Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
-| <a name="input_database_connection_ssl"></a> [database\_connection\_ssl](#input\_database\_connection\_ssl) | Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |
 | <a name="input_database_sort_buffer_size"></a> [database\_sort\_buffer\_size](#input\_database\_sort\_buffer\_size) | Specifies the sort\_buffer\_size value to set for the database | `number` | `262144` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Version for MySQL | `string` | `"MYSQL_8_0_31"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the instance should have deletion protection enabled. The database / Bucket can't be deleted when this value is set to `true`. | `bool` | `true` | no |
 | <a name="input_disable_code_saving"></a> [disable\_code\_saving](#input\_disable\_code\_saving) | Boolean indicating if code saving is disabled | `bool` | `false` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain for accessing the Weights & Biases UI. | `string` | `null` | no |
+| <a name="input_force_ssl"></a> [force\_ssl](#input\_force\_ssl) | Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string | `bool` | `false` | no |
 | <a name="input_gke_machine_type"></a> [gke\_machine\_type](#input\_gke\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"n1-standard-4"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to resources | `map(string)` | `{}` | no |
 | <a name="input_license"></a> [license](#input\_license) | Your wandb/local license | `string` | n/a | yes |

--- a/examples/public-dns-with-cloud-dns/main.tf
+++ b/examples/public-dns-with-cloud-dns/main.tf
@@ -34,6 +34,7 @@ module "wandb" {
 
   create_redis       = false
   use_internal_queue = true
+  force_ssl          = var.force_ssl
 
   deletion_protection = false
 

--- a/examples/public-dns-with-cloud-dns/variables.tf
+++ b/examples/public-dns-with-cloud-dns/variables.tf
@@ -56,6 +56,12 @@ variable "database_sort_buffer_size" {
   default     = 262144
 }
 
+variable "force_ssl" {
+  description = "Enforce SSL through the usage of the Cloud SQL Proxy (cloudsql://) in the DB connection string"
+  type        = bool
+  default     = false
+}
+
 variable "database_machine_type" {
   description = "Specifies the machine type to be allocated for the database"
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -131,9 +131,8 @@ locals {
 }
 
 module "gke_app" {
-  # source  = "wandb/wandb/kubernetes"
-  # version = "1.4.1"
-  source = "github.com/wandb/terraform-kubernetes-wandb?ref=recreate_pod_with_new_db_connection_string"
+  source  = "wandb/wandb/kubernetes"
+  version = "1.6.0"
 
   license = var.license
 

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,7 @@ module "database" {
   source              = "./modules/database"
   namespace           = var.namespace
   database_version    = var.database_version
+  # database_connection_ssl = true
   tier                = var.database_machine_type
   sort_buffer_size    = var.database_sort_buffer_size
   network_connection  = local.network_connection
@@ -138,7 +139,7 @@ module "gke_app" {
   host                       = local.url
   bucket                     = "gs://${local.bucket}"
   bucket_queue               = local.bucket_queue
-  database_connection_string = "mysql://${module.database.connection_string}"
+  database_connection_string = module.database.connection_string
   redis_connection_string    = local.redis_connection_string
   redis_ca_cert              = local.redis_certificate
 

--- a/main.tf
+++ b/main.tf
@@ -102,16 +102,16 @@ module "app_lb" {
 }
 
 module "database" {
-  source              = "./modules/database"
-  namespace           = var.namespace
-  database_version    = var.database_version
-  # database_connection_ssl = true
-  tier                = var.database_machine_type
-  sort_buffer_size    = var.database_sort_buffer_size
-  network_connection  = local.network_connection
-  deletion_protection = var.deletion_protection
-  labels              = var.labels
-  depends_on          = [module.project_factory_project_services]
+  source                = "./modules/database"
+  namespace             = var.namespace
+  database_version      = var.database_version
+  ssl_connection_string = var.database_connection_ssl
+  tier                  = var.database_machine_type
+  sort_buffer_size      = var.database_sort_buffer_size
+  network_connection    = local.network_connection
+  deletion_protection   = var.deletion_protection
+  labels                = var.labels
+  depends_on            = [module.project_factory_project_services]
 }
 
 module "redis" {

--- a/main.tf
+++ b/main.tf
@@ -131,8 +131,9 @@ locals {
 }
 
 module "gke_app" {
-  source  = "wandb/wandb/kubernetes"
-  version = "1.4.1"
+  # source  = "wandb/wandb/kubernetes"
+  # version = "1.4.1"
+  source = "../terraform-kubernetes-wandb"
 
   license = var.license
 

--- a/main.tf
+++ b/main.tf
@@ -131,9 +131,8 @@ locals {
 }
 
 module "gke_app" {
-  # source  = "wandb/wandb/kubernetes"
-  # version = "1.4.1"
-  source = "../terraform-kubernetes-wandb"
+  source  = "wandb/wandb/kubernetes"
+  version = "1.4.1"
 
   license = var.license
 

--- a/main.tf
+++ b/main.tf
@@ -131,8 +131,9 @@ locals {
 }
 
 module "gke_app" {
-  source  = "wandb/wandb/kubernetes"
-  version = "1.4.1"
+  # source  = "wandb/wandb/kubernetes"
+  # version = "1.4.1"
+  source = "github.com/wandb/terraform-kubernetes-wandb?ref=recreate_pod_with_new_db_connection_string"
 
   license = var.license
 

--- a/main.tf
+++ b/main.tf
@@ -102,16 +102,16 @@ module "app_lb" {
 }
 
 module "database" {
-  source                = "./modules/database"
-  namespace             = var.namespace
-  database_version      = var.database_version
-  ssl_connection_string = var.database_connection_ssl
-  tier                  = var.database_machine_type
-  sort_buffer_size      = var.database_sort_buffer_size
-  network_connection    = local.network_connection
-  deletion_protection   = var.deletion_protection
-  labels                = var.labels
-  depends_on            = [module.project_factory_project_services]
+  source              = "./modules/database"
+  namespace           = var.namespace
+  database_version    = var.database_version
+  force_ssl           = var.force_ssl
+  tier                = var.database_machine_type
+  sort_buffer_size    = var.database_sort_buffer_size
+  network_connection  = local.network_connection
+  deletion_protection = var.deletion_protection
+  labels              = var.labels
+  depends_on          = [module.project_factory_project_services]
 }
 
 module "redis" {

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -50,6 +50,7 @@ resource "google_sql_database_instance" "default" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = var.network_connection.network
+      require_ssl     = var.force_ssl
     }
 
     # requires minimum memory of 26624 MB

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -26,7 +26,7 @@ output "password" {
 }
 
 output "connection_string" {
-  value = var.ssl_connection_string ? local.output_connection_string_cloudsql : local.output_connection_string_mysql
+  value = var.force_ssl ? local.output_connection_string_cloudsql : local.output_connection_string_mysql
 }
 
 output "database_connection_name" {

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -24,9 +24,12 @@ output "password" {
 }
 
 output "connection_string" {
-  value = "${local.output_username}:${local.output_password}@${local.output_private_ip}/${local.output_database_name}"
+  value = var.use_cloud_proxy ? "mysql://${local.output_username}:${local.output_password}@${local.output_private_ip}/${local.output_database_name}" : "cloudsql://${local.output_username}:${local.output_password}@${local.output_connection_name}/${local.output_database_name}"
 }
 
 output "database_connection_name" {
   value = google_sql_database_instance.default.connection_name
 }
+
+
+# cloudsql://USER:PASSWORD@tmp-terraform-permissions.europe-west2.tf-perms-gcp-primary-mollusk/DATABASE

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -1,9 +1,11 @@
 locals {
-  output_private_ip      = google_sql_database_instance.default.private_ip_address
-  output_database_name   = google_sql_database.wandb.name
-  output_username        = google_sql_user.wandb.name
-  output_password        = google_sql_user.wandb.password
-  output_connection_name = replace(google_sql_database_instance.default.connection_name, ":", ".")
+  output_private_ip                 = google_sql_database_instance.default.private_ip_address
+  output_database_name              = google_sql_database.wandb.name
+  output_username                   = google_sql_user.wandb.name
+  output_password                   = google_sql_user.wandb.password
+  output_connection_name            = replace(google_sql_database_instance.default.connection_name, ":", ".")
+  output_connection_string_mysql    = "mysql://${local.output_username}:${local.output_password}@${local.output_private_ip}/${local.output_database_name}"
+  output_connection_string_cloudsql = "cloudsql://${local.output_username}:${local.output_password}@${local.output_connection_name}/${local.output_database_name}"
 }
 
 output "private_ip_address" {
@@ -24,12 +26,10 @@ output "password" {
 }
 
 output "connection_string" {
-  value = var.use_cloud_proxy ? "mysql://${local.output_username}:${local.output_password}@${local.output_private_ip}/${local.output_database_name}" : "cloudsql://${local.output_username}:${local.output_password}@${local.output_connection_name}/${local.output_database_name}"
+  value = var.ssl_connection_string ? local.output_connection_string_cloudsql : local.output_connection_string_mysql
 }
 
 output "database_connection_name" {
   value = google_sql_database_instance.default.connection_name
 }
 
-
-# cloudsql://USER:PASSWORD@tmp-terraform-permissions.europe-west2.tf-perms-gcp-primary-mollusk/DATABASE

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -65,3 +65,10 @@ variable "sort_buffer_size" {
   type        = number
   default     = 262144
 }
+
+
+variable "use_cloud_proxy" {
+  description = "Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string"
+  type        = bool
+  default     = false
+}

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -68,7 +68,7 @@ variable "sort_buffer_size" {
 
 
 variable "force_ssl" {
-  description = "Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string"
+  description = "Enforce SSL through the usage of the Cloud SQL Proxy (cloudsql://) in the DB connection string"
   type        = bool
   default     = false
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -67,7 +67,7 @@ variable "sort_buffer_size" {
 }
 
 
-variable "use_cloud_proxy" {
+variable "ssl_connection_string" {
   description = "Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string"
   type        = bool
   default     = false

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -67,7 +67,7 @@ variable "sort_buffer_size" {
 }
 
 
-variable "ssl_connection_string" {
+variable "force_ssl" {
   description = "Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string"
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -147,7 +147,7 @@ variable "database_sort_buffer_size" {
 }
 
 variable "force_ssl" {
-  description = "Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string"
+  description = "Enforce SSL through the usage of the Cloud SQL Proxy (cloudsql://) in the DB connection string"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -146,6 +146,12 @@ variable "database_sort_buffer_size" {
   default     = 262144
 }
 
+variable "database_connection_ssl" {
+  description = "Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string"
+  type        = bool
+  default     = false
+}
+
 ##########################################
 # Redis                                  #
 ##########################################

--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "database_sort_buffer_size" {
   default     = 262144
 }
 
-variable "database_connection_ssl" {
+variable "force_ssl" {
   description = "Enable the SSL through the usage of Cloud Proxy (cloudsql://) in the DB connection string"
   type        = bool
   default     = false


### PR DESCRIPTION
Switch to enable the MySQL connection via GCP Cloud Proxy with native SSL using the `cloudsql://` in the connection string