### PR TITLE
feat: Update kube version gcp

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ locals {
 
 module "gke_app" {
   source  = "wandb/wandb/kubernetes"
-  version = "1.6.0"
+  version = "1.7.0"
 
   license = var.license
 

--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ locals {
 
 module "gke_app" {
   source  = "wandb/wandb/kubernetes"
-  version = "1.7.0"
+  version = var.kube_tf_version
 
   license = var.license
 

--- a/variables.tf
+++ b/variables.tf
@@ -188,3 +188,9 @@ variable "other_wandb_env" {
   description = "Extra environment variables for W&B"
   default     = {}
 }
+
+variable "kube_tf_version" {
+  type        = string
+  description = "Kubernetes terraform version to use"
+  default     = "1.7.0"
+}


### PR DESCRIPTION
This PR adds a variable for kubernetes terraform version so that we can control this directly from core instead of opening two PRs in two repos.