### PR TITLE
feat: Require inbound cidrs be set explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided. | `list(string)` | n/a | yes |
+| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | (Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges allowed access to the instance. This must be explicitly provided, and by default is set to ["*"] to allow all connections. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to ["*"] | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, as is set to `["*"]` in the definition in the module root. | `list(string)` | n/a | yes |
+| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to ["*"] | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to ["*"] | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges allowed access to the instance. This must be explicitly provided, and by default is set to ["*"] to allow all connections. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided. | `list(string)` | n/a | yes |
+| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, as is set to `["*"]` in the definition in the module root. | `list(string)` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | (Optional) Allow HTTP(S) traffic to W&B. No default is provided, so this must be explicitly defined. | `list(string)` | <pre>[<br>  \["*"\]<br>]</pre> | no |
+| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | (Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | (Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | n/a | yes |
+| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided. | `list(string)` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | (Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | (Optional) Allow HTTP(S) traffic to W&B. No default is provided, so this must be explicitly defined. | `list(string)` | <pre>[<br>  \["*"\]<br>]</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_inbound_cidr"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | (Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | (Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |

--- a/examples/byob/variables.tf
+++ b/examples/byob/variables.tf
@@ -1,7 +1,7 @@
 variable "allowed_inbound_cidrs" {
   type        = list(string)
   nullable    = false
-  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  description = "Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided."
 }
 
 variable "project_id" {

--- a/examples/byob/variables.tf
+++ b/examples/byob/variables.tf
@@ -1,3 +1,9 @@
+variable "allowed_inbound_cidrs" {
+  type        = list(string)
+  nullable    = false
+  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+}
+
 variable "project_id" {
   type        = string
   description = "Project ID"

--- a/examples/public-dns-with-cloud-dns/main.tf
+++ b/examples/public-dns-with-cloud-dns/main.tf
@@ -22,6 +22,7 @@ provider "kubernetes" {
 module "wandb" {
   source = "../../"
 
+  allowed_inbound_cidrs = var.allowed_inbound_cidrs
   namespace   = var.namespace
   license     = var.license
   domain_name = var.domain_name

--- a/examples/public-dns-with-cloud-dns/variables.tf
+++ b/examples/public-dns-with-cloud-dns/variables.tf
@@ -1,7 +1,7 @@
 variable "allowed_inbound_cidrs" {
   type        = list(string)
   nullable    = false
-  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  description = "Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided."
 }
 
 variable "project_id" {

--- a/examples/public-dns-with-cloud-dns/variables.tf
+++ b/examples/public-dns-with-cloud-dns/variables.tf
@@ -1,3 +1,9 @@
+variable "allowed_inbound_cidrs" {
+  type        = list(string)
+  nullable    = false
+  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+}
+
 variable "project_id" {
   type        = string
   description = "Project ID"

--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ module "app_lb" {
   group                = module.app_gke.instance_group_url
   service_account      = module.service_accounts.service_account
   labels               = var.labels
-  allowed_inbound_cidr = var.allowed_inbound_cidr
+  allowed_inbound_cidrs = var.allowed_inbound_cidrs
 
   depends_on = [module.project_factory_project_services, module.app_gke]
 }

--- a/modules/app_lb/main.tf
+++ b/modules/app_lb/main.tf
@@ -10,7 +10,7 @@ module "url_map" {
   target_port          = var.target_port
   network              = var.network
   ip_address           = google_compute_global_address.default.address
-  allowed_inbound_cidr = var.allowed_inbound_cidr
+  allowed_inbound_cidrs = var.allowed_inbound_cidrs
 }
 
 module "http" {

--- a/modules/app_lb/url_map/main.tf
+++ b/modules/app_lb/url_map/main.tf
@@ -59,7 +59,7 @@ resource "google_compute_security_policy" "default" {
     match {
       versioned_expr = "SRC_IPS_V1"
       config {
-        src_ip_ranges = var.allowed_inbound_cidr
+        src_ip_ranges = var.allowed_inbound_cidrs
       }
     }
     description = "allow list rule"

--- a/modules/app_lb/url_map/variables.tf
+++ b/modules/app_lb/url_map/variables.tf
@@ -1,4 +1,4 @@
-variable "allowed_inbound_cidr" {
+variable "allowed_inbound_cidrs" {
   description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
   nullable    = false
   type        = list(string)

--- a/modules/app_lb/url_map/variables.tf
+++ b/modules/app_lb/url_map/variables.tf
@@ -1,5 +1,5 @@
 variable "allowed_inbound_cidrs" {
-  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  description = "Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided."
   nullable    = false
   type        = list(string)
 }

--- a/modules/app_lb/url_map/variables.tf
+++ b/modules/app_lb/url_map/variables.tf
@@ -1,19 +1,20 @@
-variable "namespace" {
-  type        = string
-  description = "Friendly name prefix used for tagging and naming AWS resources."
-}
-
-variable "ip_address" {
-  type = string
+variable "allowed_inbound_cidr" {
+  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  nullable    = false
+  type        = list(string)
 }
 
 variable "group" {
   type = string
 }
 
-variable "target_port" {
-  type    = number
-  default = 32543
+variable "ip_address" {
+  type = string
+}
+
+variable "namespace" {
+  description = "Friendly name prefix used for tagging and naming AWS resources."
+  type        = string
 }
 
 variable "network" {
@@ -21,8 +22,10 @@ variable "network" {
   type        = object({ self_link = string })
 }
 
-variable "allowed_inbound_cidr" {
-  type        = list(string)
-  default     = ["*"]
-  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+variable "target_port" {
+  default = 32543
+  type    = number
 }
+
+
+

--- a/modules/app_lb/variables.tf
+++ b/modules/app_lb/variables.tf
@@ -1,4 +1,4 @@
-variable "allowed_inbound_cidr" {
+variable "allowed_inbound_cidrs" {
   description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
   nullable    = false
   type        = list(string)

--- a/modules/app_lb/variables.tf
+++ b/modules/app_lb/variables.tf
@@ -1,5 +1,5 @@
 variable "allowed_inbound_cidrs" {
-  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  description = "Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided."
   nullable    = false
   type        = list(string)
 }

--- a/modules/app_lb/variables.tf
+++ b/modules/app_lb/variables.tf
@@ -1,11 +1,7 @@
-variable "namespace" {
-  type        = string
-  description = "Friendly name prefix used for tagging and naming AWS resources."
-}
-
-variable "service_account" {
-  description = "The service account associated with the GKE cluster instances that host Weights & Biases."
-  type        = object({ email = string })
+variable "allowed_inbound_cidr" {
+  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  nullable    = false
+  type        = list(string)
 }
 
 variable "fqdn" {
@@ -13,24 +9,8 @@ variable "fqdn" {
   description = "The FQDN to the W&B application"
 }
 
-variable "ssl" {
-  type        = bool
-  default     = true
-  description = "Enable SSL certificate"
-}
-
 variable "group" {
   type = string
-}
-
-variable "target_port" {
-  type    = number
-  default = 32543
-}
-
-variable "network" {
-  description = "Google Compute Engine network to which the cluster is connected."
-  type        = object({ self_link = string })
 }
 
 variable "labels" {
@@ -39,8 +19,24 @@ variable "labels" {
   default     = {}
 }
 
-variable "allowed_inbound_cidr" {
-  type        = list(string)
-  default     = ["*"]
-  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+variable "namespace" {
+  type        = string
+  description = "Friendly name prefix used for tagging and naming AWS resources."
+}
+variable "network" {
+  description = "Google Compute Engine network to which the cluster is connected."
+  type        = object({ self_link = string })
+}
+variable "service_account" {
+  description = "The service account associated with the GKE cluster instances that host Weights & Biases."
+  type        = object({ email = string })
+}
+variable "ssl" {
+  type        = bool
+  default     = true
+  description = "Enable SSL certificate"
+}
+variable "target_port" {
+  type    = number
+  default = 32543
 }

--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "subnetwork" {
 variable "allowed_inbound_cidrs" {
   type        = list(string)
   nullable    = false
-  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  description = "Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided."
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,7 @@ variable "subnetwork" {
   type        = string
 }
 
-variable "allowed_inbound_cidr" {
+variable "allowed_inbound_cidrss" {
   type        = list(string)
   nullable    = false
   description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."

--- a/variables.tf
+++ b/variables.tf
@@ -116,9 +116,10 @@ variable "subnetwork" {
 }
 
 variable "allowed_inbound_cidrs" {
-  type        = list(string)
+  default     = ["*"]
+  description = "Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to [\"*\"]"
   nullable    = false
-  description = "Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided."
+  type        = list(string)
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,7 @@ variable "subnetwork" {
   type        = string
 }
 
-variable "allowed_inbound_cidrss" {
+variable "allowed_inbound_cidrs" {
   type        = list(string)
   nullable    = false
   description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."

--- a/variables.tf
+++ b/variables.tf
@@ -117,7 +117,7 @@ variable "subnetwork" {
 
 variable "allowed_inbound_cidr" {
   type        = list(string)
-  default     = ["*"]
+  nullable    = false
   description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
 }
 


### PR DESCRIPTION
This PR  **requires** that a value be **explicitly** provided for `allowed_inbound_cidrs`. To allow all inbound connections, the value `["*"]` should be used; this is the value set in the root of the module. To restrict access to specific IPs and/or IP ranges, use CIDR notation:
```
allowed_inbound_cidrs = [ "x.x.x.x/32", "x.x.x.x/24" ]
```

This change is also reflected in the examples.