### PR TITLE
feat: Amend resource limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ No resources.
 | <a name="input_oidc_secret"></a> [oidc\_secret](#input\_oidc\_secret) | The Client secret of application in your identity provider | `string` | `""` | no |
 | <a name="input_other_wandb_env"></a> [other\_wandb\_env](#input\_other\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_resource_limits"></a> [resource\_limits](#input\_resource\_limits) | Specifies the resource limits for the wandb deployment | `map(string)` | <pre>{<br>  "cpu": 4,<br>  "memory": "15G"<br>}</pre> | no |
-| <a name="input_resource_requests"></a> [resource\_requests](#input\_resource\_requests) | Specifies the resource requests for the wandb deployment | `map(string)` | <pre>{<br>  "cpu": 4,<br>  "memory": "15G"<br>}</pre> | no |
+| <a name="input_resource_requests"></a> [resource\_requests](#input\_resource\_requests) | Specifies the resource requests for the wandb deployment | `map(string)` | <pre>{<br>  "cpu": 2,<br>  "memory": "8G"<br>}</pre> | no |
 | <a name="input_ssl"></a> [ssl](#input\_ssl) | Enable SSL certificate | `bool` | `true` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain for accessing the Weights & Biases UI. Default creates record at Route53 Route. | `string` | `null` | no |
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Pre-existing subnetwork self link | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "resource_requests" {
   description = "Specifies the resource requests for the wandb deployment"
   type        = map(string)
   default = {
-    cpu    = 4
+    cpu    = 2
     memory = "8G"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ variable "resource_requests" {
   type        = map(string)
   default = {
     cpu    = 4
-    memory = "15G"
+    memory = "8G"
   }
 }
 


### PR DESCRIPTION
This PR amends the resource requests to half what the resource limits are. With requests = limits, k8s isn't able to spinup new pods if there are existing pods on the node.