### PR TITLE
fix: Remove unused var from BYBO example

### DIFF
--- a/examples/byob/variables.tf
+++ b/examples/byob/variables.tf
@@ -1,9 +1,3 @@
-variable "allowed_inbound_cidrs" {
-  type        = list(string)
-  nullable    = false
-  description = "Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided."
-}
-
 variable "project_id" {
   type        = string
   description = "Project ID"


### PR DESCRIPTION
chore: Remove unused var from BYBO example