### PR TITLE
fix: Fix Redis Tier

### DIFF
--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -1,0 +1,35 @@
+locals {
+  # Specifications for t-shirt sized deployments
+  deployment_size = {
+    small = {
+      db            = "db-n1-highmem-2",
+      node_count    = 2,
+      node_instance = "n2-highmem-4"
+      cache         = "6"
+    },
+    medium = {
+      db            = "db-n1-highmem-4",
+      node_count    = 2,
+      node_instance = "n2-highmem-4"
+      cache         = "6"
+    },
+    large = {
+      db            = "db-n1-highmem-8",
+      node_count    = 2,
+      node_instance = "n2-highmem-8"
+      cache         = "13"
+    },
+    xlarge = {
+      db            = "db-n1-highmem-16",
+      node_count    = 3,
+      node_instance = "n2-highmem-8"
+      cache         = "13"
+    },
+    xxlarge = {
+      db            = "db-n1-highmem-32",
+      node_count    = 3,
+      node_instance = "n2-highmem-16"
+      cache         = "26"
+    }
+  }
+}

--- a/examples/public-dns-with-cloud-dns/main.tf
+++ b/examples/public-dns-with-cloud-dns/main.tf
@@ -33,7 +33,7 @@ module "wandb" {
   wandb_version = var.wandb_version
   wandb_image   = var.wandb_image
 
-  create_redis       = false
+  create_redis       = var.create_redis
   use_internal_queue = true
   force_ssl          = var.force_ssl
 

--- a/examples/public-dns-with-cloud-dns/variables.tf
+++ b/examples/public-dns-with-cloud-dns/variables.tf
@@ -4,6 +4,13 @@ variable "allowed_inbound_cidrs" {
   description = "Which IPv4 addresses/ranges to allow access. No default -- this must be explicitly provided."
 }
 
+variable "create_redis" {
+  default     = false
+  description = "Boolean indicating whether to provision an redis instance (true) or not (false)."
+  nullable    = false
+  type        = bool
+}
+
 variable "project_id" {
   type        = string
   description = "Project ID"

--- a/main.tf
+++ b/main.tf
@@ -27,40 +27,6 @@ locals {
   internal_app_port = 32543
   create_bucket     = var.bucket_name == ""
   create_network    = var.network == null
-
-  # Specifications for t-shirt sized deployments
-  deployment_size = {
-    small = {
-      db            = "db-n1-highmem-2",
-      node_count    = 2,
-      node_instance = "n2-highmem-4"
-      cache         = "Standard 6 GB"
-    },
-    medium = {
-      db            = "db-n1-highmem-4",
-      node_count    = 2,
-      node_instance = "n2-highmem-4"
-      cache         = "Standard 6 GB"
-    },
-    large = {
-      db            = "db-n1-highmem-8",
-      node_count    = 2,
-      node_instance = "n2-highmem-8"
-      cache         = "Standard 13 GB"
-    },
-    xlarge = {
-      db            = "db-n1-highmem-16",
-      node_count    = 3,
-      node_instance = "n2-highmem-8"
-      cache         = "Standard 13 GB"
-    },
-    xxlarge = {
-      db            = "db-n1-highmem-32",
-      node_count    = 3,
-      node_instance = "n2-highmem-16"
-      cache         = "Standard 26 GB"
-    }
-  }
 }
 
 module "service_accounts" {
@@ -153,11 +119,11 @@ module "redis" {
   count             = var.create_redis ? 1 : 0
   source            = "./modules/redis"
   namespace         = var.namespace
-  memory_size_gb    = 4
+  memory_size_gb    = coalesce(try(local.deployment_size[var.size].cache, null), var.database_machine_type)
   network           = local.network
   reserved_ip_range = var.redis_reserved_ip_range
   labels            = var.labels
-  tier              = coalesce(try(local.deployment_size[var.size].cache, null), var.redis_tier)
+  tier              = var.redis_tier
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,8 @@ module "redis" {
   count             = var.create_redis ? 1 : 0
   source            = "./modules/redis"
   namespace         = var.namespace
-  memory_size_gb    = coalesce(try(local.deployment_size[var.size].cache, null), var.database_machine_type)
+  ### here we set the default to 6gb, which is = setting for "small" standard size
+  memory_size_gb    = coalesce(try(local.deployment_size[var.size].cache, 6))
   network           = local.network
   reserved_ip_range = var.redis_reserved_ip_range
   labels            = var.labels


### PR DESCRIPTION
This PR merges changes that ensure a Redis cluster is created when `create_redis` is set to `true` in the examples. It also sets the default db size to 6g, which is = the size of the "small" standard size Redis instance.