### PR TITLE
fix: Pass through env vars for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ module "wandb" {
 
 ## Examples
 
-We have included documentation and reference examples for additional common
-installation scenarios for Weights & Biases, as well as examples for supporting
+We have included documentation and reference examples for common
+installation scenarios, as well as examples for supporting
 resources that lack official modules.
 
 - [Public Instance with HTTPS using Cloud DNS](examples/public-dns-with-cloud-dns)

--- a/main.tf
+++ b/main.tf
@@ -161,12 +161,6 @@ module "gke_app" {
     "GORILLA_GLUE_LIST"                    = true
   }, var.other_wandb_env)
 
-  weave_wandb_env = var.weave_wandb_env
-
-  app_wandb_env = var.app_wandb_env
-
-  parquet_wandb_env = var.parquet_wandb_env
-
   wandb_image    = var.wandb_image
   wandb_version  = var.wandb_version
   wandb_replicas = 0

--- a/modules/app_gke/variables.tf
+++ b/modules/app_gke/variables.tf
@@ -22,6 +22,25 @@ variable "machine_type" {
   type = string
 }
 
+variable "weave_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+variable "app_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+variable "parquet_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+
 variable "node_count" {
   type = number
 }


### PR DESCRIPTION
This PR passes through env vars specific to certain services to the Helm chart used to install W&B.