### PR TITLE
feat: Added example tf for customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ No resources.
 | <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to ["*"] | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_app_wandb_env"></a> [app\_wandb\_env](#input\_app\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
+| <a name="input_create_database"></a> [create\_database](#input\_create\_database) | Create sql database | `bool` | `true` | no |
+| <a name="input_create_gke"></a> [create\_gke](#input\_create\_gke) | Create gke cluster | `bool` | `true` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
+| <a name="input_database_env"></a> [database\_env](#input\_database\_env) | n/a | <pre>object({<br>    name               = string<br>    database_name      = string<br>    username           = string<br>    password           = string<br>    private_ip_address = string<br>    connection_string  = string<br>  })</pre> | <pre>{<br>  "connection_string": null,<br>  "database_name": null,<br>  "name": null,<br>  "password": null,<br>  "private_ip_address": null,<br>  "username": null<br>}</pre> | no |
 | <a name="input_database_machine_type"></a> [database\_machine\_type](#input\_database\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"db-n1-standard-2"` | no |
 | <a name="input_database_sort_buffer_size"></a> [database\_sort\_buffer\_size](#input\_database\_sort\_buffer\_size) | Specifies the sort\_buffer\_size value to set for the database | `number` | `67108864` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Version for MySQL | `string` | `"MYSQL_8_0_31"` | no |
@@ -117,10 +120,13 @@ No resources.
 | <a name="input_oidc_secret"></a> [oidc\_secret](#input\_oidc\_secret) | The Client secret of application in your identity provider | `string` | `""` | no |
 | <a name="input_other_wandb_env"></a> [other\_wandb\_env](#input\_other\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_parquet_wandb_env"></a> [parquet\_wandb\_env](#input\_parquet\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
+| <a name="input_redis_ca_cert"></a> [redis\_ca\_cert](#input\_redis\_ca\_cert) | n/a | `string` | `""` | no |
+| <a name="input_redis_env"></a> [redis\_env](#input\_redis\_env) | n/a | <pre>object({<br>    password = string<br>    host     = string<br>    port     = string<br>    connection_string = string<br>  })</pre> | <pre>{<br>  "connection_string": null,<br>  "host": null,<br>  "password": null,<br>  "port": null<br>}</pre> | no |
 | <a name="input_redis_reserved_ip_range"></a> [redis\_reserved\_ip\_range](#input\_redis\_reserved\_ip\_range) | Reserved IP range for REDIS peering connection | `string` | `"10.30.0.0/16"` | no |
 | <a name="input_redis_tier"></a> [redis\_tier](#input\_redis\_tier) | Specifies the tier for this Redis instance | `string` | `"STANDARD_HA"` | no |
 | <a name="input_resource_limits"></a> [resource\_limits](#input\_resource\_limits) | Specifies the resource limits for the wandb deployment | `map(string)` | <pre>{<br>  "cpu": null,<br>  "memory": null<br>}</pre> | no |
 | <a name="input_resource_requests"></a> [resource\_requests](#input\_resource\_requests) | Specifies the resource requests for the wandb deployment | `map(string)` | <pre>{<br>  "cpu": "2000m",<br>  "memory": "2G"<br>}</pre> | no |
+| <a name="input_self_redis"></a> [self\_redis](#input\_self\_redis) | n/a | `bool` | `false` | no |
 | <a name="input_size"></a> [size](#input\_size) | Deployment size for the instance | `string` | `null` | no |
 | <a name="input_ssl"></a> [ssl](#input\_ssl) | Enable SSL certificate | `bool` | `true` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain for accessing the Weights & Biases UI. Default creates record at Route53 Route. | `string` | `null` | no |

--- a/examples/custom-tf-with-existing-network-and-sql/main.tf
+++ b/examples/custom-tf-with-existing-network-and-sql/main.tf
@@ -26,16 +26,8 @@ provider "helm" {
   }
 }
 
-data "google_compute_network" "network" {
-  name = var.network
-}
-
-data "google_compute_subnetwork" "subnetwork" {
-  name = var.subnetwork
-}
-
-
 # Spin up all required services
+
 module "wandb" {
   source                = "../../"
   namespace             = var.namespace
@@ -49,16 +41,19 @@ module "wandb" {
   wandb_image           = var.wandb_image
   disable_code_saving   = var.disable_code_saving
   size                  = var.size
+  weave_wandb_env       = var.weave_wandb_env
+  app_wandb_env         = var.app_wandb_env
+  parquet_wandb_env     = var.parquet_wandb_env
+  other_wandb_env       = var.other_wandb_env
   labels                = var.labels
   create_redis          = var.create_redis
   local_restore         = false
   use_internal_queue    = true
   force_ssl             = false
   deletion_protection   = false
-  network               = var.network
-  network_link          = data.google_compute_network.network.self_link
-  subnetwork            = data.google_compute_subnetwork.subnetwork.id
-  create_database       = var.create_database
+  network               = var.network  # must be network created already
+  subnetwork            = var.subnetwork  # must be subnet created already
+  create_database       = false # must be false
   database_env          = var.database_env
 }
 

--- a/examples/custom-tf-with-existing-network-and-sql/main.tf
+++ b/examples/custom-tf-with-existing-network-and-sql/main.tf
@@ -1,0 +1,87 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+data "google_client_config" "current" {}
+
+provider "kubernetes" {
+  host                   = "https://${module.wandb.cluster_endpoint}"
+  cluster_ca_certificate = base64decode(module.wandb.cluster_ca_certificate)
+  token                  = data.google_client_config.current.access_token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${module.wandb.cluster_endpoint}"
+    cluster_ca_certificate = base64decode(module.wandb.cluster_ca_certificate)
+    token                  = data.google_client_config.current.access_token
+  }
+}
+
+data "google_compute_network" "network" {
+  name = var.network
+}
+
+data "google_compute_subnetwork" "subnetwork" {
+  name = var.subnetwork
+}
+
+
+# Spin up all required services
+module "wandb" {
+  source                = "../../"
+  namespace             = var.namespace
+  license               = var.license
+  allowed_inbound_cidrs = var.allowed_inbound_cidrs
+  domain_name           = var.domain_name
+  subdomain             = var.subdomain
+  gke_machine_type      = var.gke_machine_type
+  gke_node_count        = var.gke_node_count
+  wandb_version         = var.wandb_version
+  wandb_image           = var.wandb_image
+  disable_code_saving   = var.disable_code_saving
+  size                  = var.size
+  labels                = var.labels
+  create_redis          = var.create_redis
+  local_restore         = false
+  use_internal_queue    = true
+  force_ssl             = false
+  deletion_protection   = false
+  network               = var.network
+  network_link          = data.google_compute_network.network.self_link
+  subnetwork            = data.google_compute_subnetwork.subnetwork.id
+  create_database       = var.create_database
+  database_env          = var.database_env
+}
+
+output "url" {
+  value = module.wandb.url
+}
+
+output "address" {
+  value = module.wandb.address
+}
+
+output "bucket_name" {
+  value = module.wandb.bucket_name
+}
+
+output "standardized_size" {
+  value = var.size
+}
+
+output "gke_node_count" {
+  value = module.wandb.gke_node_count
+}
+
+output "gke_node_instance_type" {
+  value = module.wandb.gke_node_instance_type
+}

--- a/examples/custom-tf-with-existing-network-and-sql/variables.tf
+++ b/examples/custom-tf-with-existing-network-and-sql/variables.tf
@@ -1,9 +1,3 @@
-variable "namespace" {
-  type        = string
-  description = "String used for prefix resources."
-  default = ""
-}
-
 variable "project_id" {
   type        = string
   description = "Project ID"
@@ -20,6 +14,12 @@ variable "zone" {
   type        = string
   description = "Google zone"
   default = "us-central1-b"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Namespace prefix used for resources"
+  default = ""
 }
 
 variable "domain_name" {
@@ -48,7 +48,7 @@ variable "gke_node_count" {
 variable "license" {
   type = string
   default = ""
- }
+  }
 
 
 variable "wandb_image" {
@@ -67,6 +67,29 @@ variable "size" {
   description = "Deployment size for the instance"
   type        = string
   default     = null
+}
+
+variable "weave_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+variable "app_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+variable "parquet_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+variable "other_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
 }
 
 variable "labels" {

--- a/examples/custom-tf-with-existing-network-and-sql/variables.tf
+++ b/examples/custom-tf-with-existing-network-and-sql/variables.tf
@@ -1,0 +1,167 @@
+variable "namespace" {
+  type        = string
+  description = "String used for prefix resources."
+  default = ""
+}
+
+variable "project_id" {
+  type        = string
+  description = "Project ID"
+  default = ""
+}
+
+variable "region" {
+  type        = string
+  description = "Google region"
+  default = "us-central1"
+}
+
+variable "zone" {
+  type        = string
+  description = "Google zone"
+  default = "us-central1-b"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name for accessing the Weights & Biases UI."
+  default = ""
+}
+
+variable "subdomain" {
+  type        = string
+  default     = null
+  description = "Subdomain for access the Weights & Biases UI."
+}
+
+variable "gke_machine_type" {
+  description = "Specifies the machine type to be allocated for the database"
+  type        = string
+  default     = "n1-standard-4"
+}
+
+variable "gke_node_count" {
+  type    = number
+  default = 2
+}
+
+variable "license" {
+  type = string
+  default = ""
+ }
+
+
+variable "wandb_image" {
+  description = "Docker repository of to pull the wandb image from."
+  type        = string
+  default     = "wandb/local"
+}
+
+variable "disable_code_saving" {
+  type        = bool
+  description = "Boolean indicating if code saving is disabled"
+  default     = false
+}
+
+variable "size" {
+  description = "Deployment size for the instance"
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels to apply to resources"
+  default     = {}
+}
+
+variable "wandb_version" {
+  description = "The version of Weights & Biases local to deploy."
+  type        = string
+  default     = "latest"
+}
+
+variable "resource_limits" {
+  description = "Specifies the resource limits for the wandb deployment"
+  type        = map(string)
+  default = {
+    cpu    = null
+    memory = null
+  }
+}
+
+variable "resource_requests" {
+  description = "Specifies the resource requests for the wandb deployment"
+  type        = map(string)
+  default = {
+    cpu    = "2000m"
+    memory = "2G"
+  }
+}
+
+
+variable "allowed_inbound_cidrs" {
+  default     = ["*"]
+  description = "Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to [\"*\"]"
+  nullable    = false
+  type        = list(string)
+}
+
+variable "create_redis" {
+  type        = bool
+  description = "Boolean indicating whether to provision an redis instance (true) or not (false)."
+  default     = true
+}
+
+
+variable "redis_reserved_ip_range" {
+  type        = string
+  description = "Reserved IP range for REDIS peering connection"
+  default     = "10.30.0.0/16"
+}
+
+variable "redis_tier" {
+  type        = string
+  description = "Specifies the tier for this Redis instance"
+  default     = "STANDARD_HA"
+}
+
+variable "network" {
+  nullable    = false
+  default     = ""
+  description = "Pre-existing network self link"
+  type        = string
+}
+
+variable "subnetwork" {
+  nullable    = false
+  default     = ""
+  description = "Pre-existing subnetwork self link"
+  type        = string
+}
+
+variable "create_database" {
+  type        = bool
+  default     = false
+}
+
+variable "database_env" {
+  nullable    = false
+  type = object({
+    name               = string
+    database_name      = string
+    username           = string
+    password           = string
+    private_ip_address = string
+    connection_string  = string
+  })
+
+  default = {
+    name = "**"
+    username = "**"
+    password = "**"
+    database_name =  "**"
+    private_ip_address =  "**"
+    connection_string = "**" # "mysql://${username}:${password}@${private_ip_address}/${database_name}"
+  }
+}

--- a/examples/custom-tf-with-existing-resource/main.tf
+++ b/examples/custom-tf-with-existing-resource/main.tf
@@ -1,0 +1,72 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+data "google_client_config" "current" {}
+
+data "google_container_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.cluster.endpoint}"
+  cluster_ca_certificate = base64decode(data.google_container_cluster.cluster.master_auth.0.cluster_ca_certificate)
+  token                  = data.google_client_config.current.access_token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${data.google_container_cluster.cluster.endpoint}"
+    cluster_ca_certificate = base64decode(data.google_container_cluster.cluster.master_auth.0.cluster_ca_certificate)
+    token                  = data.google_client_config.current.access_token
+  }
+}
+
+data "google_redis_instance" "my_instance" {
+  name = var.redis_cluster_name
+}
+
+module "wandb" {
+  source              = "../../"
+  namespace           = var.namespace
+  license             = var.license
+  domain_name         = var.domain_name
+  subdomain           = var.subdomain
+  redis_ca_cert       = data.google_redis_instance.my_instance.server_ca_certs[0].cert
+  wandb_image         = var.wandb_image
+  wandb_version       = var.wandb_version
+  resource_limits     = var.resource_limits
+  resource_requests   = var.resource_requests
+  disable_code_saving = var.disable_code_saving
+  redis_env           = var.redis_env
+  database_env        = var.database_env
+  network             = var.network
+  subnetwork          = var.subnetwork
+  labels              = var.labels
+  create_redis        = false # must be false 
+  create_gke          = false # must be false 
+  create_database     = false # must be false
+  self_redis          = true  # must be true
+  use_internal_queue  = true
+  deletion_protection = false
+}
+
+output "url" {
+  value = module.wandb.url
+}
+
+output "address" {
+  value = module.wandb.address
+}
+
+output "bucket_name" {
+  value = module.wandb.bucket_name
+}

--- a/examples/custom-tf-with-existing-resource/variables.tf
+++ b/examples/custom-tf-with-existing-resource/variables.tf
@@ -34,21 +34,12 @@ variable "subdomain" {
   description = "Subdomain for access the Weights & Biases UI."
 }
 
-variable "gke_machine_type" {
-  description = "Specifies the machine type to be allocated for the database"
-  type        = string
-  default     = "n1-standard-4"
-}
-
-variable "gke_node_count" {
-  type    = number
-  default = 2
-}
 
 variable "license" {
   type = string
   default = ""
   }
+
 
 variable "wandb_image" {
   description = "Docker repository of to pull the wandb image from."
@@ -56,28 +47,10 @@ variable "wandb_image" {
   default     = "wandb/local"
 }
 
-variable "database_sort_buffer_size" {
-  description = "Specifies the sort_buffer_size value to set for the database"
-  type        = number
-  default     = 262144
-}
-
-variable "database_machine_type" {
-  description = "Specifies the machine type to be allocated for the database"
-  type        = string
-  default     = "db-n1-standard-2"
-}
-
 variable "disable_code_saving" {
   type        = bool
   description = "Boolean indicating if code saving is disabled"
   default     = false
-}
-
-variable "size" {
-  description = "Deployment size for the instance"
-  type        = string
-  default     = null
 }
 
 variable "weave_wandb_env" {
@@ -133,35 +106,80 @@ variable "resource_requests" {
   }
 }
 
-
-variable "allowed_inbound_cidrs" {
-  default     = ["*"]
-  description = "Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to [\"*\"]"
-  nullable    = false
-  type        = list(string)
-}
-
-variable "database_version" {
-  description = "Version for MySQL"
-  type        = string
-  default     = "MYSQL_8_0_31"
-}
-
-
 variable "create_redis" {
   type        = bool
   description = "Boolean indicating whether to provision an redis instance (true) or not (false)."
-  default     = true
+  default     = false
 }
 
-variable "redis_reserved_ip_range" {
-  type        = string
-  description = "Reserved IP range for REDIS peering connection"
-  default     = "10.30.0.0/16"
+variable "redis_cluster_name" {
+  type = string
+  default = ""
 }
 
-variable "redis_tier" {
+variable "redis_env" {
+  nullable    = false
+  type = object({
+    password = string
+    host     = string
+    port     = string
+    connection_string = string
+  })
+
+  default = {
+    password = "***"
+    host     = "**"
+    port     = "6378"
+    connection_string = "redis://:<password>@<host>:6378?tls=true&caCertPath=/etc/ssl/certs/redis_ca.pem&ttlInSeconds=604800"
+  }
+}
+variable "network" {
+  nullable    = false
+  default     = ""
+  description = "Pre-existing network self link"
   type        = string
-  description = "Specifies the tier for this Redis instance"
-  default     = "STANDARD_HA"
+}
+
+variable "subnetwork" {
+  nullable    = false
+  default     = ""
+  description = "Pre-existing subnetwork self link"
+  type        = string
+}
+
+variable "create_database" {
+  type        = bool
+  default     = false
+}
+
+variable "database_env" {
+  nullable    = false
+  type = object({
+    name               = string
+    database_name      = string
+    username           = string
+    password           = string
+    private_ip_address = string
+    connection_string  = string
+  })
+
+  default = {
+    name = "**"
+    username = "**"
+    password = "**"
+    database_name =  "**"
+    private_ip_address =  "**"
+    connection_string = "**" # "mysql://${username}:${password}@${private_ip_address}/${database_name}"
+  }
+}
+
+variable "cluster_name" {
+  type = string
+  description = "gke cluster name where you wanted to host your workload"
+  default = ""
+}
+
+variable "create_gke" {
+  type = bool
+  default = false
 }

--- a/examples/standard-tf/main.tf
+++ b/examples/standard-tf/main.tf
@@ -28,16 +28,16 @@ provider "helm" {
 
 # Spin up all required services
 module "wandb" {
-  source                = "../../"
-  namespace             = var.namespace
-  license               = var.license
-  allowed_inbound_cidrs = var.allowed_inbound_cidrs
-  domain_name           = var.domain_name
-  subdomain             = var.subdomain
-  gke_machine_type      = var.gke_machine_type
-  gke_node_count        = var.gke_node_count
-  wandb_version         = var.wandb_version
-  wandb_image           = var.wandb_image
+  source                    = "../../"
+  namespace                 = var.namespace
+  license                   = var.license
+  allowed_inbound_cidrs     = var.allowed_inbound_cidrs
+  domain_name               = var.domain_name
+  subdomain                 = var.subdomain
+  gke_machine_type          = var.gke_machine_type
+  gke_node_count            = var.gke_node_count
+  wandb_version             = var.wandb_version
+  wandb_image               = var.wandb_image
   database_sort_buffer_size = var.database_sort_buffer_size
   database_machine_type     = var.database_machine_type
   disable_code_saving       = var.disable_code_saving
@@ -48,7 +48,7 @@ module "wandb" {
   other_wandb_env           = var.other_wandb_env
   labels                    = var.labels
   database_version          = var.database_version
-  create_redis          = var.create_redis
+  create_redis              = var.create_redis
   local_restore             = false
   use_internal_queue        = true
   force_ssl                 = false

--- a/examples/standard-tf/main.tf
+++ b/examples/standard-tf/main.tf
@@ -1,0 +1,84 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+data "google_client_config" "current" {}
+
+provider "kubernetes" {
+  host                   = "https://${module.wandb.cluster_endpoint}"
+  cluster_ca_certificate = base64decode(module.wandb.cluster_ca_certificate)
+  token                  = data.google_client_config.current.access_token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${module.wandb.cluster_endpoint}"
+    cluster_ca_certificate = base64decode(module.wandb.cluster_ca_certificate)
+    token                  = data.google_client_config.current.access_token
+  }
+}
+
+# Spin up all required services
+module "wandb" {
+  source                = "../../"
+  namespace             = var.namespace
+  license               = var.license
+  allowed_inbound_cidrs = var.allowed_inbound_cidrs
+  domain_name           = var.domain_name
+  subdomain             = var.subdomain
+  gke_machine_type      = var.gke_machine_type
+  gke_node_count        = var.gke_node_count
+  wandb_version         = var.wandb_version
+  wandb_image           = var.wandb_image
+  database_sort_buffer_size = var.database_sort_buffer_size
+  database_machine_type     = var.database_machine_type
+  disable_code_saving       = var.disable_code_saving
+  size                      = var.size
+  weave_wandb_env           = var.weave_wandb_env
+  app_wandb_env             = var.app_wandb_env
+  parquet_wandb_env         = var.parquet_wandb_env
+  other_wandb_env           = var.other_wandb_env
+  labels                    = var.labels
+  database_version          = var.database_version
+  create_redis          = var.create_redis
+  local_restore             = false
+  use_internal_queue        = true
+  force_ssl                 = false
+  deletion_protection       = false
+}
+
+output "url" {
+  value = module.wandb.url
+}
+
+output "address" {
+  value = module.wandb.address
+}
+
+output "bucket_name" {
+  value = module.wandb.bucket_name
+}
+
+output "standardized_size" {
+  value = var.size
+}
+
+output "gke_node_count" {
+  value = module.wandb.gke_node_count
+}
+
+output "gke_node_instance_type" {
+  value = module.wandb.gke_node_instance_type
+}
+
+output "database_instance_type" {
+  value = module.wandb.database_instance_type
+}

--- a/examples/standard-tf/variables.tf
+++ b/examples/standard-tf/variables.tf
@@ -1,0 +1,168 @@
+variable "namespace" {
+  type        = string
+  description = "String used for prefix resources."
+  default = ""
+}
+
+variable "project_id" {
+  type        = string
+  description = "Project ID"
+  default = ""
+}
+
+variable "region" {
+  type        = string
+  description = "Google region"
+  default = ""
+}
+
+variable "zone" {
+  type        = string
+  description = "Google zone"
+  default = ""
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name for accessing the Weights & Biases UI."
+  default = ""
+}
+
+variable "subdomain" {
+  type        = string
+  default     = null
+  description = "Subdomain for access the Weights & Biases UI."
+}
+
+variable "gke_machine_type" {
+  description = "Specifies the machine type to be allocated for the database"
+  type        = string
+  default     = "n1-standard-4"
+}
+
+variable "gke_node_count" {
+  type    = number
+  default = 2
+}
+
+variable "license" {
+  type = string
+  default = ""
+  }
+
+
+variable "wandb_image" {
+  description = "Docker repository of to pull the wandb image from."
+  type        = string
+  default     = "wandb/local"
+}
+
+variable "database_sort_buffer_size" {
+  description = "Specifies the sort_buffer_size value to set for the database"
+  type        = number
+  default     = 262144
+}
+
+variable "database_machine_type" {
+  description = "Specifies the machine type to be allocated for the database"
+  type        = string
+  default     = "db-n1-standard-2"
+}
+
+variable "disable_code_saving" {
+  type        = bool
+  description = "Boolean indicating if code saving is disabled"
+  default     = false
+}
+
+variable "size" {
+  description = "Deployment size for the instance"
+  type        = string
+  default     = null
+}
+
+variable "weave_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+variable "app_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+variable "parquet_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+variable "other_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels to apply to resources"
+  default     = {}
+}
+
+variable "wandb_version" {
+  description = "The version of Weights & Biases local to deploy."
+  type        = string
+  default     = "latest"
+}
+
+variable "resource_limits" {
+  description = "Specifies the resource limits for the wandb deployment"
+  type        = map(string)
+  default = {
+    cpu    = null
+    memory = null
+  }
+}
+
+variable "resource_requests" {
+  description = "Specifies the resource requests for the wandb deployment"
+  type        = map(string)
+  default = {
+    cpu    = "2000m"
+    memory = "2G"
+  }
+}
+
+
+variable "allowed_inbound_cidrs" {
+  default     = ["*"]
+  description = "Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to [\"*\"]"
+  nullable    = false
+  type        = list(string)
+}
+
+variable "database_version" {
+  description = "Version for MySQL"
+  type        = string
+  default     = "MYSQL_8_0_31"
+}
+
+
+variable "create_redis" {
+  type        = bool
+  description = "Boolean indicating whether to provision an redis instance (true) or not (false)."
+  default     = true
+}
+
+variable "redis_reserved_ip_range" {
+  type        = string
+  description = "Reserved IP range for REDIS peering connection"
+  default     = "10.30.0.0/16"
+}
+
+variable "redis_tier" {
+  type        = string
+  description = "Specifies the tier for this Redis instance"
+  default     = "STANDARD_HA"
+}

--- a/modules/app_lb/variables.tf
+++ b/modules/app_lb/variables.tf
@@ -9,9 +9,9 @@ variable "fqdn" {
   description = "The FQDN to the W&B application"
 }
 
-variable "group" {
-  type = string
-}
+# variable "group" {
+#   type = string
+# }
 
 variable "labels" {
   description = "Labels which will be applied to all applicable resources."

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,7 +50,7 @@ output "cluster_self_link" {
 }
 
 output "database_connection_string" {
-  value       = module.database.connection_string
+  value       = var.create_database ? module.database.0.connection_string : null
   sensitive   = true
   description = "Full database connection string. You must be in the VPC to access the database."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,41 +11,41 @@ output "bucket_queue_name" {
   description = "Pubsub queue created for google bucket file upload events."
 }
 output "cluster_ca_certificate" {
-  value       = module.app_gke.cluster_ca_certificate
+  value       = var.create_gke ? module.app_gke.0.cluster_ca_certificate : null
   sensitive   = true
   description = "Certificate of the kubernetes (GKE) cluster."
 }
 
 output "cluster_client_certificate" {
   sensitive = true
-  value     = module.app_gke.cluster_client_certificate
+  value     = var.create_gke ? module.app_gke.0.cluster_client_certificate : null
 }
 
 output "cluster_client_key" {
   sensitive = true
-  value     = module.app_gke.cluster_client_key
+  value     = var.create_gke ? module.app_gke.0.cluster_client_key : null
 }
 output "cluster_endpoint" {
-  value       = module.app_gke.cluster_endpoint
+  value       = var.create_gke ? module.app_gke.0.cluster_endpoint : null
   description = "Endpoint of the kubernetes (GKE) cluster."
 }
 
 output "cluster_id" {
-  value       = module.app_gke.cluster_id
+  value       = var.create_gke ? module.app_gke.0.cluster_id : null
   description = "ID of the kubernetes (GKE) cluster."
 }
 
 output "cluster_name" {
-  value = module.app_gke.cluster_name
+  value = var.create_gke ? module.app_gke.0.cluster_name : null
 }
 
 output "cluster_node_pool" {
-  value       = module.app_gke.node_pool
+  value       = var.create_gke ? module.app_gke.0.node_pool : null
   description = "Default node pool where Weights & Biases should be deployed into."
 }
 
 output "cluster_self_link" {
-  value       = module.app_gke.cluster_self_link
+  value       = var.create_gke ? module.app_gke.0.cluster_self_link : null
   description = "Self link of the kubernetes (GKE) cluster."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "network" {
   description = "Pre-existing network self link"
   type        = string
 }
+ 
+variable "network_link" {
+  description = "Pre-existing network self link"
+  type        = string
+  default = null
+}
 
 variable "subnetwork" {
   default     = null
@@ -141,6 +147,30 @@ variable "ssl" {
 ##########################################
 # Database                               #
 ##########################################
+variable "create_database" {
+  type        = bool
+  default     = true
+}
+
+variable "database_env" {
+  type = object({
+    name               = string
+    database_name      = string
+    username           = string
+    password           = string
+    private_ip_address = string
+    connection_string  = string
+  })
+  default = { 
+    name               = null
+    database_name      = null
+    username           = null
+    password           = null
+    private_ip_address = null
+    connection_string  = null
+  }
+}
+
 variable "database_version" {
   description = "Version for MySQL"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -102,12 +102,6 @@ variable "network" {
   description = "Pre-existing network self link"
   type        = string
 }
- 
-variable "network_link" {
-  description = "Pre-existing network self link"
-  type        = string
-  default = null
-}
 
 variable "subnetwork" {
   default     = null
@@ -147,8 +141,15 @@ variable "ssl" {
 ##########################################
 # Database                               #
 ##########################################
+variable "database_version" {
+  description = "Version for MySQL"
+  type        = string
+  default     = "MYSQL_8_0_31"
+}
+
 variable "create_database" {
   type        = bool
+  description = "Create sql database"
   default     = true
 }
 
@@ -169,12 +170,6 @@ variable "database_env" {
     private_ip_address = null
     connection_string  = null
   }
-}
-
-variable "database_version" {
-  description = "Version for MySQL"
-  type        = string
-  default     = "MYSQL_8_0_31"
 }
 
 variable "database_machine_type" {
@@ -198,10 +193,38 @@ variable "force_ssl" {
 ##########################################
 # Redis                                  #
 ##########################################
+
 variable "create_redis" {
   type        = bool
   description = "Boolean indicating whether to provision an redis instance (true) or not (false)."
   default     = false
+}
+
+variable "self_redis" {
+   default     = false
+   type        = bool
+}
+
+variable "redis_ca_cert" {
+   type        = string
+   default = ""
+}
+
+variable "redis_env" {
+  nullable    = false
+  type = object({
+    password = string
+    host     = string
+    port     = string
+    connection_string = string
+  })
+
+  default = {
+    password = null
+    host     = null
+    port     = null
+    connection_string = null
+  }
 }
 
 variable "redis_reserved_ip_range" {
@@ -242,6 +265,12 @@ variable "gke_machine_type" {
 variable "gke_node_count" {
   type    = number
   default = 2
+}
+
+variable "create_gke" {
+  type = bool
+  description = "Create gke cluster"
+  default = true
 }
 
 ##########################################


### PR DESCRIPTION
1. Standard TF deployment using k8s operator in GCP  - creating new VPC / VNet, new  GKE cluster, new MySQL cluster, and new Redis cache.
2. Custom TF deployment using k8s operator in  GCP  - in an existing VPC & pre-created subnets, connecting to an existing MySQL cluster, new GKE cluster, and new Redis cache.
3. Custom TF deployment using k8s operator in GCP- in an existing VPC & pre-created subnets, connecting to an existing MySQL cluster, using an existing GKE cluster, and an existing Redis cache.