### PR TITLE
fix: Consistent object type for redis

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -232,7 +232,17 @@ module "wandb" {
             ttlInSeconds = 604800
             caCertPath   = "/etc/ssl/certs/redis_ca.pem"
           }
-        } : {}
+          } : {
+          password = ""
+          host     = ""
+          port     = 0
+          caCert   = ""
+          params = {
+            tls          = false
+            ttlInSeconds = 0
+            caCertPath   = ""
+          }
+        }
       }
 
       app = {
@@ -255,9 +265,9 @@ module "wandb" {
         }
         serviceAccount = { annotations = { "iam.gke.io/gcp-service-account" = module.service_accounts.monitoring_role } }
         } : {
-          install        = false
-          stackdriver    = {}
-          serviceAccount = {}
+        install        = false
+        stackdriver    = {}
+        serviceAccount = {}
       }
 
       otel = {


### PR DESCRIPTION
fixing:
`The true and false result expressions must have consistent types. The 'true' value includes object attribute "caCert", which is absent in the 'false' value.`