### PR TITLE
feat: Add optional path var for instance level bucket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ resources that lack official modules.
 |------|-------------|
 | <a name="output_address"></a> [address](#output\_address) | n/a |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of google bucket. |
+| <a name="output_bucket_path"></a> [bucket\_path](#output\_bucket\_path) | path of where to store data for the instance-level bucket. |
 | <a name="output_bucket_queue_name"></a> [bucket\_queue\_name](#output\_bucket\_queue\_name) | Pubsub queue created for google bucket file upload events. |
 | <a name="output_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#output\_cluster\_ca\_certificate) | Certificate of the kubernetes (GKE) cluster. |
 | <a name="output_cluster_client_certificate"></a> [cluster\_client\_certificate](#output\_cluster\_client\_certificate) | n/a |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ resources that lack official modules.
 
 ## Inputs
 
-<<<<<<< HEAD
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to ["*"] | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ resources that lack official modules.
 | <a name="input_bucket_kms_key_id"></a> [bucket\_kms\_key\_id](#input\_bucket\_kms\_key\_id) | ID of the customer-provided bucket KMS key. | `string` | `null` | no |
 | <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location of the bucket (US, EU, ASIA) | `string` | `"US"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
-| <a name="input_bucket_path"></a> [bucket\_path](#input\_bucket\_path) | path of where to store data within the instance-level bucket                                                                      | `string` | `""` | no |
+| <a name="input_bucket_path"></a> [bucket\_path](#input\_bucket\_path) | path of where to store data for the instance-level bucket | `string` | `""` | no |
 | <a name="input_create_private_link"></a> [create\_private\_link](#input\_create\_private\_link) | Whether to create a private link service. | `bool` | `false` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_create_workload_identity"></a> [create\_workload\_identity](#input\_create\_workload\_identity) | Flag to indicate whether to create a workload identity for the service account. | `bool` | `false` | no |
@@ -160,7 +160,7 @@ resources that lack official modules.
 |------|-------------|
 | <a name="output_address"></a> [address](#output\_address) | n/a |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of google bucket. |
-| <a name="output_bucket_path"></a> [bucket\_path](#output\_bucket\_path) | path of where to store data for the instance-level bucket. |
+| <a name="output_bucket_path"></a> [bucket\_path](#output\_bucket\_path) | path of where to store data for the instance-level bucket |
 | <a name="output_bucket_queue_name"></a> [bucket\_queue\_name](#output\_bucket\_queue\_name) | Pubsub queue created for google bucket file upload events. |
 | <a name="output_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#output\_cluster\_ca\_certificate) | Certificate of the kubernetes (GKE) cluster. |
 | <a name="output_cluster_client_certificate"></a> [cluster\_client\_certificate](#output\_cluster\_client\_certificate) | n/a |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ resources that lack official modules.
 
 ## Inputs
 
+<<<<<<< HEAD
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to ["*"] | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
@@ -110,6 +111,7 @@ resources that lack official modules.
 | <a name="input_bucket_kms_key_id"></a> [bucket\_kms\_key\_id](#input\_bucket\_kms\_key\_id) | ID of the customer-provided bucket KMS key. | `string` | `null` | no |
 | <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location of the bucket (US, EU, ASIA) | `string` | `"US"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Use an existing bucket. | `string` | `""` | no |
+| <a name="input_bucket_path"></a> [bucket\_path](#input\_bucket\_path) | path of where to store data within the instance-level bucket                                                                      | `string` | `""` | no |
 | <a name="input_create_private_link"></a> [create\_private\_link](#input\_create\_private\_link) | Whether to create a private link service. | `bool` | `false` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_create_workload_identity"></a> [create\_workload\_identity](#input\_create\_workload\_identity) | Flag to indicate whether to create a workload identity for the service account. | `bool` | `false` | no |

--- a/examples/public-dns-with-cloud-dns/main.tf
+++ b/examples/public-dns-with-cloud-dns/main.tf
@@ -71,6 +71,10 @@ output "bucket_name" {
   value = module.wandb.bucket_name
 }
 
+output "bucket_path" {
+  value = module.wandb.bucket_path
+}
+
 output "standardized_size" {
   value = var.size
 }

--- a/examples/public-dns-with-cloud-dns/main.tf
+++ b/examples/public-dns-with-cloud-dns/main.tf
@@ -36,6 +36,8 @@ module "wandb" {
   domain_name           = var.domain_name
   subdomain             = var.subdomain
 
+  bucket_path = var.bucket_path
+
   gke_machine_type = var.gke_machine_type
 
   wandb_version = var.wandb_version

--- a/examples/public-dns-with-cloud-dns/variables.tf
+++ b/examples/public-dns-with-cloud-dns/variables.tf
@@ -21,6 +21,12 @@ variable "region" {
   description = "Google region"
 }
 
+variable "bucket_path" {
+  description = "path of where to store data for the instance-level bucket"
+  type        = string
+  default     = ""
+}
+
 variable "zone" {
   type        = string
   description = "Google zone"

--- a/main.tf
+++ b/main.tf
@@ -253,7 +253,7 @@ module "wandb" {
         bucket = {
           provider = "gcs"
           name     = local.bucket
-          path  = var.path
+          path     = var.bucket_path
         }
 
         mysql = {

--- a/main.tf
+++ b/main.tf
@@ -253,6 +253,7 @@ module "wandb" {
         bucket = {
           provider = "gcs"
           name     = local.bucket
+          subpath  = var.subpath
         }
 
         mysql = {

--- a/main.tf
+++ b/main.tf
@@ -253,7 +253,7 @@ module "wandb" {
         bucket = {
           provider = "gcs"
           name     = local.bucket
-          subpath  = var.subpath
+          path  = var.path
         }
 
         mysql = {

--- a/main.tf
+++ b/main.tf
@@ -164,6 +164,7 @@ locals {
   redis_connection_string = var.create_redis ? "redis://:${module.redis[0].auth_string}@${module.redis[0].connection_string}?tls=true&ttlInSeconds=604800&caCertPath=/etc/ssl/certs/server_ca.pem" : null
   bucket                  = local.create_bucket ? module.storage[0].bucket_name : var.bucket_name
   bucket_queue            = var.use_internal_queue ? "internal://" : "pubsub:/${module.storage[0].bucket_queue_name}"
+  bucket_path             = var.bucket_path
   project_id              = module.project_factory_project_services.project_id
   secret_store_source     = "gcp-secretmanager://${local.project_id}?namespace=${var.namespace}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "bucket_name" {
 }
 output "bucket_path" {
   value       = local.bucket_path
-  descritpion = "path of where to store data for the instance-level bucket"
+  description = "path of where to store data for the instance-level bucket"
 }
 output "bucket_queue_name" {
   value       = local.bucket_queue

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,10 @@ output "bucket_name" {
   value       = local.bucket
   description = "Name of google bucket."
 }
-
+output "bucket_path" {
+  value       = local.bucket_path
+  descritpion = "path of where to store data for the instance-level bucket"
+}
 output "bucket_queue_name" {
   value       = local.bucket_queue
   description = "Pubsub queue created for google bucket file upload events."

--- a/variables.tf
+++ b/variables.tf
@@ -207,11 +207,11 @@ variable "bucket_location" {
 ##########################################
 # Bucket Subpath                         #
 ##########################################
-# Most users will not need this setting. It is meant for users who want to store
-# all of their instance-level bucket's data at a specific subpath. It can be set both for
+# This setting is meant for users who want to store all of their instance-level
+# bucket's data at a specific path within their bucket. It can be set both for
 # external buckets or the bucket created by this module.
-variable "subpath" {
-  description = "subpath of where to store data for the instance-level bucket"
+variable "path" {
+  description = "path of where to store data for the instance-level bucket"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -205,6 +205,18 @@ variable "bucket_location" {
 }
 
 ##########################################
+# Bucket Subpath                         #
+##########################################
+# Most users will not need this setting. It is meant for users who want to store
+# all of their instance-level bucket's data at a specific subpath. It can be set both for
+# external buckets or the bucket created by this module.
+variable "subpath" {
+  description = "subpath of where to store data for the instance-level bucket"
+  type        = string
+  default     = ""
+}
+
+##########################################
 # K8s                                    #
 ##########################################
 

--- a/variables.tf
+++ b/variables.tf
@@ -210,7 +210,7 @@ variable "bucket_location" {
 # This setting is meant for users who want to store all of their instance-level
 # bucket's data at a specific path within their bucket. It can be set both for
 # external buckets or the bucket created by this module.
-variable "path" {
+variable "bucket_path" {
   description = "path of where to store data for the instance-level bucket"
   type        = string
   default     = ""


### PR DESCRIPTION
```
Terraform will perform the following actions:

  # module.wandb.data.google_compute_forwarding_rules.all will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "google_compute_forwarding_rules" "all" {
      + id    = (known after apply)
      + rules = (known after apply)
    }

  # module.wandb.module.wandb.helm_release.wandb will be updated in-place
  ~ resource "helm_release" "wandb" {
        id                         = "wandb-cr"
      ~ metadata                   = [
          - {
...
              - values         = jsonencode(
                    {
                      - name = "wandb"
                      - spec = <<-EOT
...
                                "bucket":
                                  "name": "andrew-levin-gcp-intense-goblin"
                                  "path": ""
                                  "provider": "gcs"
                                "cloudProvider": "gcp"
 ...

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
The new helm release spec wasn't shown when running `terraform apply`, but the updates are propagated to the deployment as expected:
- when `bucket_path` was NOT specified, when I exec'd to the wandb-app pod, I saw
```
wandb@wandb-app-65d8cb96-m7jb5:~$ env | grep -i bucket
BUCKET=gs://andrew-levin-gcp-intense-goblin
```
- when `bucket_path` was specified as `"nested/path/test", I saw
```
wandb@wandb-app-7cbb475896-79266:~$ env | grep -i nested
BUCKET=gs://andrew-levin-gcp-intense-goblin/nested/path/test
    "store": "gs://andrew-levin-gcp-intense-goblin/nested/path/test",
OVERFLOW_BUCKET_ADDR=gs://andrew-levin-gcp-intense-goblin/nested/path/test
GORILLA_FILE_STORE=gs://andrew-levin-gcp-intense-goblin/nested/path/test
```