### PR TITLE
chore(dev): add flat run fields updater service account annotation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -270,6 +270,17 @@ module "wandb" {
         }
       }
 
+       flat-run-fields-updater = {
+        extraEnvs = var.app_wandb_env
+        serviceAccount = var.create_workload_identity ? {
+          name        = var.kms_gcs_sa_name
+          annotations = { "iam.gke.io/gcp-service-account" = module.service_accounts.sa_account_role }
+          } : {
+          name        = ""
+          annotations = {}
+        }
+      }
+
       ingress = {
         create       = var.public_access # external ingress for public connection
         nameOverride = var.namespace


### PR DESCRIPTION
Suspect this is needed to fix this error message connecting to frfu overflow bucket

```
panic: googleapi: got HTTP response code 403 with body: <?xml version='1.0' encoding='UTF-8'?><Error><Code>AccessDenied</Code><Message>Access denied.</Message><Details>Caller does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).</Details></Error>
```