### PR TITLE
feat!: Service Account Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ resources that lack official modules.
 | <a name="input_gke_machine_type"></a> [gke\_machine\_type](#input\_gke\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"n1-standard-4"` | no |
 | <a name="input_gke_node_count"></a> [gke\_node\_count](#input\_gke\_node\_count) | n/a | `number` | `2` | no |
 | <a name="input_ilb_proxynetwork_cidr"></a> [ilb\_proxynetwork\_cidr](#input\_ilb\_proxynetwork\_cidr) | Internal load balancer proxy subnetwork | `string` | `"10.127.0.0/24"` | no |
-| <a name="input_kms_gcs_sa_name"></a> [kms\_gcs\_sa\_name](#input\_kms\_gcs\_sa\_name) | n/a | `string` | `"wandb-app"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to resources | `map(string)` | `{}` | no |
 | <a name="input_license"></a> [license](#input\_license) | Your wandb/local license | `string` | n/a | yes |
 | <a name="input_local_restore"></a> [local\_restore](#input\_local\_restore) | Restores W&B to a stable state if needed | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ locals {
   k8s_sa_map = {
     app       = "wandb-app"
     parquet   = "wandb-parquet"
-    flat_runs = "wandb-flat-runs-fields-updater"
+    flat_runs = "wandb-flat-run-fields-updater"
   }
 }
 

--- a/modules/app_gke/main.tf
+++ b/modules/app_gke/main.tf
@@ -77,14 +77,9 @@ resource "google_container_node_pool" "default" {
       "https://www.googleapis.com/auth/trace.append",
       "https://www.googleapis.com/auth/sqlservice.admin",
     ]
-
-     dynamic "workload_metadata_config" {
-       for_each = var.create_workload_identity == true ? [1] : []
-        content {
-          mode = "GKE_METADATA"
-        }
-      }
-    
+    workload_metadata_config {
+      mode = var.create_workload_identity ? "GKE_METADATA" : "GCE_METADATA"
+    }
     shielded_instance_config {
       enable_secure_boot = true
     }

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -120,12 +120,11 @@ resource "google_service_account_iam_member" "token_creator_binding" {
 }
 
 resource "google_service_account_iam_member" "workload_binding" {
-  count              = var.create_workload_identity == true ? 1 : 0
+  for_each           = var.create_workload_identity ? { for sa in var.kms_gcs_sa_list : sa => sa } : {}
   service_account_id = google_service_account.kms_gcs_sa[0].id
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${local.project_id}.svc.id.goog[default/${var.kms_gcs_sa_name}]"
+  member             = "serviceAccount:${local.project_id}.svc.id.goog[default/${each.value}]"
 }
-
 
 ### service account for stackdriver
 resource "google_service_account" "stackdriver" {

--- a/modules/service_accounts/variables.tf
+++ b/modules/service_accounts/variables.tf
@@ -14,8 +14,8 @@ variable "create_workload_identity" {
   type        = bool
 }
 
-variable "kms_gcs_sa_name" {
-  type    = string
+variable "kms_gcs_sa_list" {
+  type = list(string)
 }
 
 variable "stackdriver_sa_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -269,7 +269,7 @@ variable "create_private_link" {
 variable "public_access" {
   type        = bool
   description = "Whether to create a public endpoint for wandb access."
-  default = true
+  default     = true
 }
 
 variable "allowed_project_names" {
@@ -298,13 +298,9 @@ variable "create_workload_identity" {
   default     = false
 }
 
-variable "kms_gcs_sa_name" {
-  type    = string
-  default = "wandb-app"
-}
 
 variable "enable_stackdriver" {
-  type = bool
+  type    = bool
   default = false
 }
 


### PR DESCRIPTION
Service Accounts in GCP need to be mapped to the SA's in the Kubernetes Cluster. 

https://github.com/wandb/helm-charts/pull/178

Requires helm chart 0.15.0 to work with `create_workload_identity` = `true` for parts of the application. 