### PR TITLE
feat: Add optional external_bucket var for cross-cloud instance level buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ resources that lack official modules.
 | <a name="input_disable_code_saving"></a> [disable\_code\_saving](#input\_disable\_code\_saving) | Boolean indicating if code saving is disabled | `bool` | `false` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain for accessing the Weights & Biases UI. | `string` | `null` | no |
 | <a name="input_enable_stackdriver"></a> [enable\_stackdriver](#input\_enable\_stackdriver) | n/a | `bool` | `false` | no |
+| <a name="input_external_bucket"></a> [external\_bucket](#input\_external\_bucket) | config an external bucket | `any` | `null` | no |
 | <a name="input_force_ssl"></a> [force\_ssl](#input\_force\_ssl) | Enforce SSL through the usage of the Cloud SQL Proxy (cloudsql://) in the DB connection string | `bool` | `false` | no |
 | <a name="input_gke_machine_type"></a> [gke\_machine\_type](#input\_gke\_machine\_type) | Specifies the machine type to be allocated for the database | `string` | `"n1-standard-4"` | no |
 | <a name="input_gke_node_count"></a> [gke\_node\_count](#input\_gke\_node\_count) | n/a | `number` | `2` | no |

--- a/examples/public-dns-with-cloud-dns/main.tf
+++ b/examples/public-dns-with-cloud-dns/main.tf
@@ -37,6 +37,7 @@ module "wandb" {
   subdomain             = var.subdomain
 
   bucket_path = var.bucket_path
+  external_bucket = var.external_bucket
 
   gke_machine_type = var.gke_machine_type
 

--- a/examples/public-dns-with-cloud-dns/main.tf
+++ b/examples/public-dns-with-cloud-dns/main.tf
@@ -75,7 +75,9 @@ output "bucket_name" {
 output "bucket_path" {
   value = module.wandb.bucket_path
 }
-
+output "bucket_queue_name" {
+  value = module.wandb.bucket_queue_name
+}
 output "standardized_size" {
   value = var.size
 }

--- a/examples/public-dns-with-cloud-dns/variables.tf
+++ b/examples/public-dns-with-cloud-dns/variables.tf
@@ -27,6 +27,12 @@ variable "bucket_path" {
   default     = ""
 }
 
+variable "external_bucket" {
+  description = "config an external bucket"
+  type        = map(string)
+  default     = null
+}
+
 variable "zone" {
   type        = string
   description = "Google zone"

--- a/main.tf
+++ b/main.tf
@@ -162,11 +162,20 @@ module "redis" {
 locals {
   redis_certificate       = var.create_redis ? module.redis[0].ca_cert : null
   redis_connection_string = var.create_redis ? "redis://:${module.redis[0].auth_string}@${module.redis[0].connection_string}?tls=true&ttlInSeconds=604800&caCertPath=/etc/ssl/certs/server_ca.pem" : null
-  bucket                  = local.create_bucket ? module.storage[0].bucket_name : var.bucket_name
+  bucket                  = local.create_bucket ? module.storage[0].bucket_name : var.bucket_name // TODO var.external_bucket.name
   bucket_queue            = var.use_internal_queue ? "internal://" : "pubsub:/${module.storage[0].bucket_queue_name}"
   bucket_path             = var.bucket_path
   project_id              = module.project_factory_project_services.project_id
   secret_store_source     = "gcp-secretmanager://${local.project_id}?namespace=${var.namespace}"
+}
+
+locals {
+  gcp_bucket_config = {
+    provider  = "gcs"
+    name      = local.bucket
+    path      = var.bucket_path
+  }
+  bucket_config = var.external_bucket != null ? var.external_bucket : local.gcp_bucket_config
 }
 
 resource "google_compute_address" "default" {
@@ -251,11 +260,7 @@ module "wandb" {
           "TAG_CUSTOMER_NS"                      = var.namespace
         }, var.other_wandb_env, local.oidc_envs)
 
-        bucket = {
-          provider = "gcs"
-          name     = local.bucket
-          path     = var.bucket_path
-        }
+        bucket = local.bucket_config
 
         mysql = {
           name     = module.database.database_name

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ locals {
   fqdn           = var.subdomain == null ? var.domain_name : "${var.subdomain}.${var.domain_name}"
   url_prefix     = var.ssl ? "https" : "http"
   url            = "${local.url_prefix}://${local.fqdn}"
-  create_bucket  = var.bucket_name == ""
+  create_bucket  = var.bucket_name == "" && var.external_bucket == null
   create_network = var.network == null
   k8s_sa_map = {
     app         = "wandb-app"
@@ -162,7 +162,8 @@ module "redis" {
 locals {
   redis_certificate       = var.create_redis ? module.redis[0].ca_cert : null
   redis_connection_string = var.create_redis ? "redis://:${module.redis[0].auth_string}@${module.redis[0].connection_string}?tls=true&ttlInSeconds=604800&caCertPath=/etc/ssl/certs/server_ca.pem" : null
-  bucket                  = local.create_bucket ? module.storage[0].bucket_name : var.bucket_name // TODO var.external_bucket.name
+  gcp_bucket              = var.external_bucket != null ? "" : local.create_bucket ? module.storage[0].bucket_name : var.bucket_name
+  bucket                  = var.external_bucket != null ? var.external_bucket.name : local.gcp_bucket
   bucket_queue            = var.use_internal_queue ? "internal://" : "pubsub:/${module.storage[0].bucket_queue_name}"
   bucket_path             = var.bucket_path
   project_id              = module.project_factory_project_services.project_id
@@ -172,7 +173,7 @@ locals {
 locals {
   gcp_bucket_config = {
     provider  = "gcs"
-    name      = local.bucket
+    name      = local.gcp_bucket
     path      = var.bucket_path
   }
   bucket_config = var.external_bucket != null ? var.external_bucket : local.gcp_bucket_config
@@ -193,7 +194,7 @@ module "gke_app" {
   license = var.license
 
   host                       = local.url
-  bucket                     = "gs://${local.bucket}"
+  bucket                     = "gs://${local.gcp_bucket}"
   bucket_queue               = local.bucket_queue
   database_connection_string = module.database.connection_string
   redis_connection_string    = local.redis_connection_string

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "address" {
 }
 output "bucket_name" {
   value       = local.bucket
-  description = "Name of google bucket."
+  description = "Name of bucket."
 }
 output "bucket_path" {
   value       = local.bucket_path

--- a/variables.tf
+++ b/variables.tf
@@ -187,7 +187,7 @@ variable "redis_tier" {
 }
 
 ##########################################
-# External Bucket                        #
+# Existing GCP Bucket                    #
 ##########################################
 # Most users will not need these settings. They are ment for users who want a
 # bucket in a different account.
@@ -202,6 +202,19 @@ variable "bucket_location" {
   type        = string
   description = "Location of the bucket (US, EU, ASIA)"
   default     = "US"
+}
+
+
+##########################################
+# Existing External Bucket               #
+##########################################
+# Most users will not need these settings. They are ment for users who want a
+# bucket from on-prem storage or a different cloud provider.
+
+variable "external_bucket" {
+  description = "config an external bucket"
+  type        = map(string)
+  default     = null
 }
 
 ##########################################


### PR DESCRIPTION
Below the terraform plan you can see the updated env vars. Also note, tested logging a run file and artifact to this bucket to verify the queue functionality worked as expected still.

**TF plan:**
```
Terraform will perform the following actions:

  # module.wandb.data.google_compute_forwarding_rules.all will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "google_compute_forwarding_rules" "all" {
      + id    = (known after apply)
      + rules = (known after apply)
    }

  # module.wandb.module.gke_app.kubernetes_deployment.wandb will be updated in-place
  ~ resource "kubernetes_deployment" "wandb" {
        id               = "default/wandb"
        # (1 unchanged attribute hidden)

      ~ spec {
            # (5 unchanged attributes hidden)

          ~ template {
              ~ spec {
                    # (14 unchanged attributes hidden)

                  ~ container {
                        name                       = "wandb"
                        # (9 unchanged attributes hidden)

                      ~ env {
                            name  = "BUCKET"
                          ~ value = "gs://andrew-levin-gcp-humble-mule" -> "gs://"
                        }

                        # (29 unchanged blocks hidden)
                    }

         ...
    }

  # module.wandb.module.wandb.helm_release.wandb will be updated in-place
  ~ resource "helm_release" "wandb" {
        id                         = "wandb-cr"
      ~ metadata                   = [
          - {
...
              - values         = jsonencode(
                    {
                      - name = "wandb"
                      - spec = <<-EOT
                            "values":
                              "app":
                                "extraEnvs": {}
                                "serviceAccount":
                                  "annotations": {}
                                  "name": ""
                              "flat-runs-fields-updater":
                                "serviceAccount":
                                  "annotations": {}
                                  "name": null
                              "global":
                                "bucket":
                                  "name": "andrew-levin-gcp-humble-mule"
                                  "path": "nested/path"
                                  "provider": "gcs"
                                "cloudProvider": "gcp"
 ...
                        EOT
                    }
                )
              - version        = "0.1.0"
            },
        ] -> (known after apply)
        name                       = "wandb-cr"
        # (26 unchanged attributes hidden)

      - set {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }
      + set {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }

        # (1 unchanged block hidden)
    }

  # module.wandb.module.storage[0].module.bucket.google_storage_bucket.file_storage will be destroyed
  # (because module.wandb.module.storage[0].module.bucket is not in configuration)
  - resource "google_storage_bucket" "file_storage" {
...
      - url                         = "gs://andrew-levin-gcp-humble-mule" -> null
...
    }

  # module.wandb.module.storage[0].module.bucket.google_storage_bucket_iam_member.object_admin will be destroyed
  # (because module.wandb.module.storage[0].module.bucket is not in configuration)
  - resource "google_storage_bucket_iam_member" "object_admin" {
      - bucket = "b/andrew-levin-gcp-humble-mule" -> null
      - etag   = "CAI=" -> null
      - id     = "b/andrew-levin-gcp-humble-mule/roles/storage.objectAdmin/serviceAccount:<redactedServiceAccountEmail>" -> null
      - member = "serviceAccount:<redactedServiceAccountEmail>" -> null
      - role   = "roles/storage.objectAdmin" -> null
    }

  # module.wandb.module.storage[0].module.bucket.random_pet.file_storage will be destroyed
  # (because module.wandb.module.storage[0].module.bucket is not in configuration)
  - resource "random_pet" "file_storage" {
      - id        = "humble-mule" -> null
      - length    = 2 -> null
      - separator = "-" -> null
    }

Plan: 0 to add, 2 to change, 3 to destroy.

Changes to Outputs:
  ~ bucket_name            = "andrew-levin-gcp-humble-mule" -> "crosscloudsfs/ccsfstest"
  + bucket_queue_name      = "internal://"
```

**Updated env vars:**
```
wandb@wandb-app-84469f859f-zczl7:~$ env | grep -i bucket
BUCKET=az://crosscloudsfs/ccsfstest
BUCKET_QUEUE=internal://
  "overflow-bucket": {
OVERFLOW_BUCKET_ADDR=az://crosscloudsfs/ccsfstest
GORILLA_STORAGE_BUCKET=az://crosscloudsfs/ccsfstest
```