### PR TITLE
feat: Add internalJWTMap variables used for inter service request authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ resources that lack official modules.
 | <a name="input_gke_max_node_count"></a> [gke\_max\_node\_count](#input\_gke\_max\_node\_count) | Maximum number of nodes for the GKE cluster. Defaults to null and value from deployment-size.tf is used | `number` | `null` | no |
 | <a name="input_gke_min_node_count"></a> [gke\_min\_node\_count](#input\_gke\_min\_node\_count) | Initial number of nodes for the GKE cluster, if gke\_max\_node\_count is set, this is the minimum number of nodes. Defaults to null and value from deployment-size.tf is used | `number` | `null` | no |
 | <a name="input_ilb_proxynetwork_cidr"></a> [ilb\_proxynetwork\_cidr](#input\_ilb\_proxynetwork\_cidr) | Internal load balancer proxy subnetwork | `string` | `"10.127.0.0/24"` | no |
-| <a name="input_kubernetes_cluster_oidc_issuer_url"></a> [kubernetes\_cluster\_oidc\_issuer\_url](#input\_kubernetes\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the Kubernetes cluster. Can be determined using kubectl get --raw /.well-known/openid-configuration | `string` | `""` | no |
+| <a name="input_kubernetes_cluster_oidc_issuer_url"></a> [kubernetes\_cluster\_oidc\_issuer\_url](#input\_kubernetes\_cluster\_oidc\_issuer\_url) | OIDC issuer URL for the Kubernetes cluster. Can be determined using `kubectl get --raw /.well-known/openid-configuration` | `string` | `""` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to resources | `map(string)` | `{}` | no |
 | <a name="input_license"></a> [license](#input\_license) | Your wandb/local license | `string` | n/a | yes |
 | <a name="input_local_restore"></a> [local\_restore](#input\_local\_restore) | Restores W&B to a stable state if needed | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -319,8 +319,8 @@ module "wandb" {
         }
         internalJWTMap = [
           {
-            subject = "system:serviceaccount:${var.namespace}:${local.k8s_sa_map.weave_trace}"
-            issuer = var.kubernetes_oidc_issuer
+            subject = "system:serviceaccount:default:${local.k8s_sa_map.weave_trace}"
+            issuer = var.kubernetes_cluster_oidc_issuer_url
           }
         ]
       }

--- a/main.tf
+++ b/main.tf
@@ -317,6 +317,12 @@ module "wandb" {
           name        = ""
           annotations = {}
         }
+        internalJWTMap = [
+          {
+            subject = "system:serviceaccount:${var.namespace}:${local.k8s_sa_map.weave_trace}"
+            issuer = var.kubernetes_oidc_issuer
+          }
+        ]
       }
 
       ingress = {

--- a/variables.tf
+++ b/variables.tf
@@ -413,6 +413,6 @@ variable "clickhouse_subnetwork_cidr" {
 ###########################################
 variable "kubernetes_cluster_oidc_issuer_url" {
   type        = string
-  description = "OIDC issuer URL for the Kubernetes cluster. Can be determined using kubectl get --raw /.well-known/openid-configuration"
+  description = "OIDC issuer URL for the Kubernetes cluster. Can be determined using `kubectl get --raw /.well-known/openid-configuration`"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -413,6 +413,6 @@ variable "clickhouse_subnetwork_cidr" {
 ##########################################
 variable "kubernetes_oidc_issuer" {
   type        = string
-  description = "OIDC issuer URL"
+  description = "Kubernetes OIDC issuer URL"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -408,11 +408,11 @@ variable "clickhouse_subnetwork_cidr" {
   type        = string
 }
 
-##########################################
-# Internal Service                       #
-##########################################
-variable "kubernetes_oidc_issuer" {
+###########################################
+# Internal Service                        #
+###########################################
+variable "kubernetes_cluster_oidc_issuer_url" {
   type        = string
-  description = "Kubernetes OIDC issuer URL"
+  description = "OIDC issuer URL for the Kubernetes cluster. Can be determined using kubectl get --raw /.well-known/openid-configuration"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -407,3 +407,12 @@ variable "clickhouse_subnetwork_cidr" {
   description = "ClickHouse private service connect subnetwork"
   type        = string
 }
+
+##########################################
+# Internal Service                       #
+##########################################
+variable "kubernetes_oidc_issuer" {
+  type        = string
+  description = "OIDC issuer URL"
+  default     = ""
+}


### PR DESCRIPTION
Adds a new variable kubernetes_cluster_oidc_issuer_url variable, used to set the internalJWTMap issuer value in our helm charts which defines the mapping of subject to issuer, which is used to authenticate internal service communication.

Also passes the values of the internalJWTMap via tf