### PR TITLE
feat: Configure notify-keyspace-events for redis

### DIFF
--- a/modules/clickhouse/main.tf
+++ b/modules/clickhouse/main.tf
@@ -45,6 +45,6 @@ resource "google_dns_record_set" "psc_dns_record" {
   name         = "*.${var.clickhouse_region}.p.gcp.clickhouse.cloud."
   managed_zone = google_dns_managed_zone.psc_dns_zone.name
   type         = "A"
-  rrdatas      = [ google_compute_address.psc_endpoint_ip.address ]
+  rrdatas      = [google_compute_address.psc_endpoint_ip.address]
   ttl          = 3600
 }

--- a/modules/clickhouse/variables.tf
+++ b/modules/clickhouse/variables.tf
@@ -20,7 +20,7 @@ variable "clickhouse_private_endpoint_service_name" {
   default     = ""
 
   validation {
-    condition = can(regex("-clickhouse-cloud$", var.clickhouse_private_endpoint_service_name))
+    condition     = can(regex("-clickhouse-cloud$", var.clickhouse_private_endpoint_service_name))
     error_message = "ClickHouse Service name must end in '-clickhouse-cloud'."
   }
 }
@@ -31,7 +31,7 @@ variable "clickhouse_region" {
   default     = ""
 
   validation {
-    condition = length(var.clickhouse_region) > 0
+    condition     = length(var.clickhouse_region) > 0
     error_message = "Clickhouse Region should always be set if the private endpoint service name is specified."
   }
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -22,4 +22,8 @@ resource "google_redis_instance" "default" {
   auth_enabled = true
 
   labels = var.labels
+
+  redis_configs = {
+    notify-keyspace-events = "K$"
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -103,5 +103,5 @@ output "sa_account_email" {
 
 output "clickhouse_private_endpoint_id" {
   description = "ClickHouse Private endpoint Endpoint ID to secure access inside VPC"
-  value = var.clickhouse_private_endpoint_service_name != "" ? module.clickhouse[0].psc_connection_id : null
+  value       = var.clickhouse_private_endpoint_service_name != "" ? module.clickhouse[0].psc_connection_id : null
 }


### PR DESCRIPTION
Enable subscription for key updates

## Terraform plan
```
Terraform will perform the following actions:
...
  # module.wandb.module.redis[0].google_redis_instance.default will be updated in-place
  ~ resource "google_redis_instance" "default" {
        id                       = "projects/playground-111/locations/us-central1/instances/andrew-levin-gcp-two-redis"
        name                     = "andrew-levin-gcp-two-redis"
      ~ redis_configs            = {
          + "notify-keyspace-events" = "K$"
        }
...
Plan: 0 to add, 1 to change, 0 to destroy.
```

## Subscribing test
After applying the changes, I connected to the redis instance from two terminal windows. In one window I did
```
10.30.0.4:6378> PSUBSCRIBE __keyspace@0__:*
Reading messages... (press Ctrl-C to quit)
1) "psubscribe"
2) "__keyspace@0__:*"
3) (integer) 1
```
then in another I did
```
10.30.0.4:6378> SET testKey testValue
OK
```

then in the first window I saw the update come through
```
1) "pmessage"
2) "__keyspace@0__:*"
3) "__keyspace@0__:testKey"
4) "set"
```