### PR TITLE
fix: Fix database instance flag

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -30,7 +30,7 @@ data "google_project" "default" {
 
 locals {
   default_flags = {
-    "binlog_row_image"   = "MINIMAL"
+    "binlog_row_image"   = "minimal"
     "binlog_row_value_options" = "PARTIAL_JSON"
     "innodb_autoinc_lock_mode" = "2"
     "innodb_lru_scan_depth" = "100"

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -30,16 +30,16 @@ data "google_project" "default" {
 
 locals {
   default_flags = {
-    "binlog_row_image"   = "minimal"
-    "binlog_row_value_options" = "PARTIAL_JSON"
-    "innodb_autoinc_lock_mode" = "2"
-    "innodb_lru_scan_depth" = "100"
+    "binlog_row_image"           = "minimal"
+    "binlog_row_value_options"   = "PARTIAL_JSON"
+    "innodb_autoinc_lock_mode"   = "2"
+    "innodb_lru_scan_depth"      = "100"
     "innodb_print_all_deadlocks" = "off"
-    "long_query_time"    = "1"
-    "max_prepared_stmt_count" = "1048576"
-    "max_execution_time" = "60000"
-    "slow_query_log"     = "on"
-    "sort_buffer_size"   = var.sort_buffer_size
+    "long_query_time"            = "1"
+    "max_prepared_stmt_count"    = "1048576"
+    "max_execution_time"         = "60000"
+    "slow_query_log"             = "on"
+    "sort_buffer_size"           = var.sort_buffer_size
   }
   database_flags = merge(local.default_flags, var.database_flags)
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -62,9 +62,9 @@ variable "database_version" {
 }
 
 variable "database_flags" {
-    description = "Flags to set for the database"
-    type        = map(string)
-    default     = {}
+  description = "Flags to set for the database"
+  type        = map(string)
+  default     = {}
 }
 
 variable "sort_buffer_size" {


### PR DESCRIPTION
Based on the [docs](https://cloud.google.com/sql/docs/mysql/flags#:~:text=binlog_row_value_options), it should be a lowercase string 

```
Error: Error, failed to create instance sa-gcp-social-walrus: googleapi: Error 400: Value requested is not valid. Failed to set binlog_row_image: MINIMAL was not an expected string., invalidFlagValue

   with module.wandb.module.database.google_sql_database_instance.default,
   on .terraform/modules/wandb/modules/database/main.tf line 47, in resource "google_sql_database_instance" "default":
   47: resource "google_sql_database_instance" "default" {
```

After fixing it the DB creation went through.