### PR TITLE
 fix: Remove negation from redis install condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ module "wandb" {
         serviceAccount = {}
       }
 
-      redis = { install = !var.create_redis }
+      redis = { install = var.create_redis }
       mysql = { install = false }
 
       weave = {


### PR DESCRIPTION
Redis is being created even though` create_redis i`s explicitly set to `false` in the deployment using the GCP Terraform module `public-dns-with-cloud-dns.`

Here’s the variable definition:

```
variable "create_redis" {
  default     = false
  description = "Boolean indicating whether to provision a Redis instance (true) or not (false)."
  nullable    = false
  type        = bool
}
```

The logic in the module at [main.tf#L362](https://github.com/wandb/terraform-google-wandb/blob/main/main.tf#L362C6-L362C46) appears to cause the issue:

`redis = { install = !var.create_redis }`