### PR TITLE
fix: Tune mysql database flags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -321,7 +321,7 @@ module "wandb" {
         internalJWTMap = [
           {
             subject = "system:serviceaccount:default:${local.k8s_sa_map.weave_trace}"
-            issuer = var.kubernetes_cluster_oidc_issuer_url
+            issuer  = var.kubernetes_cluster_oidc_issuer_url
           }
         ]
       }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -35,13 +35,13 @@ locals {
     "innodb_autoinc_lock_mode"   = "2"
     "innodb_lru_scan_depth"      = "100"
     "innodb_print_all_deadlocks" = "off"
+    "local_infile"               = "off"
     "long_query_time"            = "1"
     "max_prepared_stmt_count"    = "1048576"
     "max_execution_time"         = "60000"
     "slow_query_log"             = "on"
     "sort_buffer_size"           = var.sort_buffer_size
     "skip_show_database"         = "on"
-    "local_infile"               = "off"
   }
   database_flags = merge(local.default_flags, var.database_flags)
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -40,6 +40,8 @@ locals {
     "max_execution_time"         = "60000"
     "slow_query_log"             = "on"
     "sort_buffer_size"           = var.sort_buffer_size
+    "skip_show_database"         = "on"
+    "local_infile"               = "off"
   }
   database_flags = merge(local.default_flags, var.database_flags)
 }


### PR DESCRIPTION
This update modifies Cloud SQL database flag configurations to ensure compliance with CIS benchmarks.

The "local_infile" database flag controls the server-side LOCAL capability for LOAD DATA statements.

Enabling the "skip_show_database" flag can improve your data security if you have concerns about users being able to see MySQL databases belonging to other users.