### PR TITLE
chore: Add ssl_mode with require_ssl

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -72,6 +72,7 @@ resource "google_sql_database_instance" "default" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = var.network_connection.network
+      ssl_mode        = var.force_ssl ? "TRUSTED_CLIENT_CERTIFICATE_REQUIRED" : "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
       require_ssl     = var.force_ssl
     }
 


### PR DESCRIPTION
require_ssl is being deprecated in TF in favor of ssl_mode, adding ssl_mode to configuration to avoid breaking functionality when terraform is upgraded.