### PR TITLE
fix: Ignore lifecycle of the locations for redis

### DIFF
--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -26,4 +26,11 @@ resource "google_redis_instance" "default" {
   redis_configs = {
     notify-keyspace-events = "K$"
   }
+
+  lifecycle {
+    ignore_changes = [
+      location_id,
+      alternative_location_id
+    ]
+  }
 }


### PR DESCRIPTION
There is a bug where the data source for the locations is sometimes nondeterministic. 

This is a workaround to prevent the deletion and recreation of the redis instance.