### PR TITLE
fix: Rework the PSC connection to support SSL and be available globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ resources that lack official modules.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.30 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 5.30 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.23 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | 0.11.2 |
@@ -87,8 +88,6 @@ resources that lack official modules.
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 5.30 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.23 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
@@ -116,14 +115,13 @@ resources that lack official modules.
 | Name | Type |
 |------|------|
 | [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
-| [kubernetes_ingress_v1.internal-lb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/ingress_v1) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to ["*"] | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
-| <a name="input_allowed_project_names"></a> [allowed\_project\_names](#input\_allowed\_project\_names) | A map of allowed projects where each key is a project number and the value is the connection limit. | `map(number)` | `{}` | no |
+| <a name="input_allowed_project_names"></a> [allowed\_project\_names](#input\_allowed\_project\_names) | A map of allowed projects where each key is a project number and the value is the connection limit. | `map(number)` | <pre>{<br/>  "wandb-qa": 20<br/>}</pre> | no |
 | <a name="input_app_wandb_env"></a> [app\_wandb\_env](#input\_app\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_bucket_default_encryption"></a> [bucket\_default\_encryption](#input\_bucket\_default\_encryption) | Boolean to determine if a default bucket encryption key should be used. If true, a default key will be created. Takes precedence over `bucket_kms_key_id`. | `bool` | `false` | no |
 | <a name="input_bucket_kms_key_id"></a> [bucket\_kms\_key\_id](#input\_bucket\_kms\_key\_id) | ID of the customer-provided bucket KMS key. | `string` | `null` | no |
@@ -207,7 +205,7 @@ resources that lack official modules.
 | <a name="output_gke_max_node_count"></a> [gke\_max\_node\_count](#output\_gke\_max\_node\_count) | n/a |
 | <a name="output_gke_node_count"></a> [gke\_node\_count](#output\_gke\_node\_count) | n/a |
 | <a name="output_gke_node_instance_type"></a> [gke\_node\_instance\_type](#output\_gke\_node\_instance\_type) | n/a |
-| <a name="output_private_attachement_id"></a> [private\_attachement\_id](#output\_private\_attachement\_id) | n/a |
+| <a name="output_private_attachment_id"></a> [private\_attachment\_id](#output\_private\_attachment\_id) | n/a |
 | <a name="output_sa_account_email"></a> [sa\_account\_email](#output\_sa\_account\_email) | This output provides the email address of the service account created for workload identity, if workload identity is enabled. Otherwise, it returns null |
 | <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Weights & Biases service account used to manage resources. |
 | <a name="output_standardized_size"></a> [standardized\_size](#output\_standardized\_size) | n/a |

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ resources that lack official modules.
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 5.30 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.23 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
@@ -106,7 +108,6 @@ resources that lack official modules.
 | <a name="module_project_factory_project_services"></a> [project\_factory\_project\_services](#module\_project\_factory\_project\_services) | terraform-google-modules/project-factory/google//modules/project_services | ~> 14.0 |
 | <a name="module_redis"></a> [redis](#module\_redis) | ./modules/redis | n/a |
 | <a name="module_service_accounts"></a> [service\_accounts](#module\_service\_accounts) | ./modules/service_accounts | n/a |
-| <a name="module_sleep"></a> [sleep](#module\_sleep) | matti/resource/shell | 1.5.0 |
 | <a name="module_storage"></a> [storage](#module\_storage) | ./modules/storage | n/a |
 | <a name="module_wandb"></a> [wandb](#module\_wandb) | wandb/wandb/helm | 1.2.0 |
 
@@ -115,7 +116,7 @@ resources that lack official modules.
 | Name | Type |
 |------|------|
 | [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
-| [google_compute_forwarding_rules.all](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_forwarding_rules) | data source |
+| [kubernetes_ingress_v1.internal-lb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/ingress_v1) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ resources that lack official modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_inbound_cidrs"></a> [allowed\_inbound\_cidrs](#input\_allowed\_inbound\_cidrs) | Which IPv4 addresses/ranges to allow access. This must be explicitly provided, and by default is set to ["*"] | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
-| <a name="input_allowed_project_names"></a> [allowed\_project\_names](#input\_allowed\_project\_names) | A map of allowed projects where each key is a project number and the value is the connection limit. | `map(number)` | <pre>{<br/>  "wandb-qa": 20<br/>}</pre> | no |
+| <a name="input_allowed_project_names"></a> [allowed\_project\_names](#input\_allowed\_project\_names) | A map of allowed projects where each key is a project number and the value is the connection limit. | `map(number)` | `{}` | no |
 | <a name="input_app_wandb_env"></a> [app\_wandb\_env](#input\_app\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_bucket_default_encryption"></a> [bucket\_default\_encryption](#input\_bucket\_default\_encryption) | Boolean to determine if a default bucket encryption key should be used. If true, a default key will be created. Takes precedence over `bucket_kms_key_id`. | `bool` | `false` | no |
 | <a name="input_bucket_kms_key_id"></a> [bucket\_kms\_key\_id](#input\_bucket\_kms\_key\_id) | ID of the customer-provided bucket KMS key. | `string` | `null` | no |

--- a/modules/app_gke/main.tf
+++ b/modules/app_gke/main.tf
@@ -105,8 +105,8 @@ resource "google_container_node_pool" "default" {
 
     kubelet_config {
       cpu_manager_policy = "none"
-      cpu_cfs_quota = true
-      pod_pids_limit = 0
+      cpu_cfs_quota      = true
+      pod_pids_limit     = 0
     }
 
     metadata = {

--- a/modules/app_gke/main.tf
+++ b/modules/app_gke/main.tf
@@ -103,6 +103,12 @@ resource "google_container_node_pool" "default" {
       enable_secure_boot = true
     }
 
+    kubelet_config {
+      cpu_manager_policy = "none"
+      cpu_cfs_quota = true
+      pod_pids_limit = 0
+    }
+
     metadata = {
       disable-legacy-endpoints = "true"
     }

--- a/modules/cloud_nat/main.tf
+++ b/modules/cloud_nat/main.tf
@@ -31,5 +31,5 @@ resource "google_compute_router_nat" "nat_lb_proxy" {
   region                             = google_compute_router.this.region
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-  endpoint_types = ["ENDPOINT_TYPE_MANAGED_PROXY_LB"]
+  endpoint_types                     = ["ENDPOINT_TYPE_MANAGED_PROXY_LB"]
 }

--- a/modules/cloud_nat/main.tf
+++ b/modules/cloud_nat/main.tf
@@ -14,10 +14,22 @@ resource "google_compute_address" "this" {
 
 # create cloud nat public gateway
 resource "google_compute_router_nat" "nat" {
+  count                              = var.vpc_nat ? 1 : 0
   name                               = "${var.namespace}-cloud-nat"
   router                             = google_compute_router.this.name
   region                             = google_compute_router.this.region
   nat_ip_allocate_option             = "MANUAL_ONLY"
   nat_ips                            = google_compute_address.this.*.self_link
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+# create cloud nat public gateway for Private Service Connect LB
+resource "google_compute_router_nat" "nat_lb_proxy" {
+  count                              = var.proxy_nat ? 1 : 0
+  name                               = "${var.namespace}-cloud-nat-lb-proxy"
+  router                             = google_compute_router.this.name
+  region                             = google_compute_router.this.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  endpoint_types = ["ENDPOINT_TYPE_MANAGED_PROXY_LB"]
 }

--- a/modules/cloud_nat/variables.tf
+++ b/modules/cloud_nat/variables.tf
@@ -6,3 +6,13 @@ variable "network" {
   description = "Google Compute Engine network to which the cluster is connected."
   type        = object({ self_link = string })
 }
+
+variable "proxy_nat" {
+  description = "Enable NAT for the Load Balancer Proxy Subnets"
+  type = bool
+}
+
+variable "vpc_nat" {
+  description = "Enable NAT for the VPC"
+  type = bool
+}

--- a/modules/cloud_nat/variables.tf
+++ b/modules/cloud_nat/variables.tf
@@ -9,10 +9,10 @@ variable "network" {
 
 variable "proxy_nat" {
   description = "Enable NAT for the Load Balancer Proxy Subnets"
-  type = bool
+  type        = bool
 }
 
 variable "vpc_nat" {
   description = "Enable NAT for the VPC"
-  type = bool
+  type        = bool
 }

--- a/modules/private_link/main.tf
+++ b/modules/private_link/main.tf
@@ -1,3 +1,15 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "5.34.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.2"
+    }
+  }
+}
 data "google_client_config" "current" {}
 
 resource "google_compute_service_attachment" "default" {
@@ -14,7 +26,9 @@ resource "google_compute_service_attachment" "default" {
       connection_limit  = consumer_accept_lists.value
     }
   }
-  depends_on = [google_compute_subnetwork.default]
+  depends_on = [
+    google_compute_subnetwork.default
+  ]
 }
 
 resource "google_compute_subnetwork" "default" {

--- a/modules/private_link/main.tf
+++ b/modules/private_link/main.tf
@@ -1,23 +1,67 @@
-terraform {
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "5.34.0"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = "3.2.2"
-    }
+data "google_client_config" "current" {}
+
+# proxy-only subnet used by internal load balancer
+resource "google_compute_subnetwork" "proxy" {
+  name          = "${var.namespace}-proxy-subnet"
+  ip_cidr_range = var.proxynetwork_cidr
+  purpose       = "REGIONAL_MANAGED_PROXY"
+  role          = "ACTIVE"
+  network       = var.network.id
+  timeouts {
+    delete = "2m"
   }
 }
-data "google_client_config" "current" {}
+
+resource "google_compute_region_network_endpoint_group" "external_lb" {
+  name = "${var.namespace}-psc-lb-neg"
+  region = data.google_client_config.current.region
+
+  network_endpoint_type = "INTERNET_FQDN_PORT"
+  network = var.network.id
+}
+
+resource "google_compute_region_network_endpoint" "external_lb" {
+  region_network_endpoint_group = google_compute_region_network_endpoint_group.external_lb.name
+
+  fqdn  = var.fqdn
+  port  = 443
+}
+
+resource "google_compute_region_backend_service" "internal_nlb" {
+  name                  = "${var.namespace}-psc-nlb"
+  protocol              = "TCP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  backend {
+    group           = google_compute_region_network_endpoint_group.external_lb.id
+    balancing_mode  = ""
+  }
+}
+
+resource "google_compute_region_target_tcp_proxy" "internal_nlb" {
+  name            = "${var.namespace}-psc-nlb"
+  backend_service = google_compute_region_backend_service.internal_nlb.id
+}
+
+resource "google_compute_forwarding_rule" "internal_nlb" {
+  name = "${var.namespace}-psc-nlb"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+
+  allow_global_access = true
+  ip_protocol = "TCP"
+  port_range  = "443"
+
+  target = google_compute_region_target_tcp_proxy.internal_nlb.id
+
+  network = var.network.id
+  subnetwork = var.subnetwork.self_link
+}
 
 resource "google_compute_service_attachment" "default" {
   name                  = "${var.namespace}-private-link"
-  enable_proxy_protocol = false
   connection_preference = "ACCEPT_MANUAL"
+  enable_proxy_protocol = false
   nat_subnets           = [google_compute_subnetwork.default.id]
-  target_service        = "https://www.googleapis.com/compute/v1/projects/${data.google_client_config.current.project}/regions/${data.google_client_config.current.region}/forwardingRules/${var.forwarding_rule}"
+  target_service        = google_compute_forwarding_rule.internal_nlb.self_link
 
   dynamic "consumer_accept_lists" {
     for_each = var.allowed_project_names != {} ? var.allowed_project_names : {}

--- a/modules/private_link/main.tf
+++ b/modules/private_link/main.tf
@@ -13,18 +13,18 @@ resource "google_compute_subnetwork" "proxy" {
 }
 
 resource "google_compute_region_network_endpoint_group" "external_lb" {
-  name = "${var.namespace}-psc-lb-neg"
+  name   = "${var.namespace}-psc-lb-neg"
   region = data.google_client_config.current.region
 
   network_endpoint_type = "INTERNET_FQDN_PORT"
-  network = var.network.id
+  network               = var.network.id
 }
 
 resource "google_compute_region_network_endpoint" "external_lb" {
   region_network_endpoint_group = google_compute_region_network_endpoint_group.external_lb.name
 
-  fqdn  = var.fqdn
-  port  = 443
+  fqdn = var.fqdn
+  port = 443
 }
 
 resource "google_compute_region_backend_service" "internal_nlb" {
@@ -32,8 +32,8 @@ resource "google_compute_region_backend_service" "internal_nlb" {
   protocol              = "TCP"
   load_balancing_scheme = "INTERNAL_MANAGED"
   backend {
-    group           = google_compute_region_network_endpoint_group.external_lb.id
-    balancing_mode  = ""
+    group          = google_compute_region_network_endpoint_group.external_lb.id
+    balancing_mode = ""
   }
 }
 
@@ -43,16 +43,16 @@ resource "google_compute_region_target_tcp_proxy" "internal_nlb" {
 }
 
 resource "google_compute_forwarding_rule" "internal_nlb" {
-  name = "${var.namespace}-psc-nlb"
+  name                  = "${var.namespace}-psc-nlb"
   load_balancing_scheme = "INTERNAL_MANAGED"
 
   allow_global_access = true
-  ip_protocol = "TCP"
-  port_range  = "443"
+  ip_protocol         = "TCP"
+  port_range          = "443"
 
   target = google_compute_region_target_tcp_proxy.internal_nlb.id
 
-  network = var.network.id
+  network    = var.network.id
   subnetwork = var.subnetwork.self_link
 }
 

--- a/modules/private_link/outputs.tf
+++ b/modules/private_link/outputs.tf
@@ -1,3 +1,3 @@
-output "private_attachement_id" {
+output "private_attachment_id" {
   value = try(google_compute_service_attachment.default.id, null)
 }

--- a/modules/private_link/variables.tf
+++ b/modules/private_link/variables.tf
@@ -14,7 +14,6 @@ variable "network" {
   type        = object({ id = string })
 }
 
-
 variable "subnetwork" {
   type = object({
     self_link = string

--- a/modules/private_link/variables.tf
+++ b/modules/private_link/variables.tf
@@ -3,12 +3,6 @@ variable "namespace" {
   description = "The name prefix for all resources created."
 }
 
-variable "labels" {
-  description = "Labels which will be applied to all applicable resources."
-  type        = map(string)
-  default     = {}
-}
-
 variable "network" {
   description = "Google Compute Engine network to which the cluster is connected."
   type        = object({ id = string })
@@ -37,7 +31,7 @@ variable "proxynetwork_cidr" {
   description = "Internal load balancer proxy subnetwork"
 }
 
-variable "forwarding_rule" {
+variable "fqdn" {
   type        = string
-  description = "forwarding rule name used in private service connect as a target"
+  description = "Fully qualified domain name or hostname"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -92,7 +92,7 @@ output "database_instance_type" {
   value = local.database_machine_type
 }
 
-output "private_attachement_id" {
+output "private_attachment_id" {
   value = var.create_private_link ? module.private_link[0].private_attachement_id : null
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -93,7 +93,7 @@ output "database_instance_type" {
 }
 
 output "private_attachment_id" {
-  value = var.create_private_link ? module.private_link[0].private_attachement_id : null
+  value = var.create_private_link ? module.private_link[0].private_attachment_id : null
 }
 
 output "sa_account_email" {

--- a/variables.tf
+++ b/variables.tf
@@ -359,7 +359,7 @@ variable "public_access" {
 variable "allowed_project_names" {
   type = map(number)
   default = {
-    # "project_ID" = 4 
+    "wandb-qa" : 20
   }
   description = "A map of allowed projects where each key is a project number and the value is the connection limit."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -359,7 +359,7 @@ variable "public_access" {
 variable "allowed_project_names" {
   type = map(number)
   default = {
-    "wandb-qa" : 20
+    # "project_ID" = 10
   }
   description = "A map of allowed projects where each key is a project number and the value is the connection limit."
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 5.30"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.30"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23"


### PR DESCRIPTION
In order for the connection on the PSC consumer side to be available globally, either the global flag on the internal load balancer must be set, or a network load balancer must be used.  Since it is not possible to set the global flag on the internal load balancer via Kubernetes Ingress, an NLB is needed.  To simplify the set for now, that NLB is just pointed to the existing application load balancer.