### PR TITLE
fix: Chunk out allowed cidrs

### DIFF
--- a/modules/app_lb/main.tf
+++ b/modules/app_lb/main.tf
@@ -34,14 +34,22 @@ resource "google_compute_security_policy_rule" "allow_internal" {
   action = "allow"
 }
 
+locals {
+  cidrs_chunked = [
+    for i in range(0, ceil(length(var.allowed_inbound_cidrs) / 10)) :
+    slice(var.allowed_inbound_cidrs, i * 10, min((i + 1) * 10, length(var.allowed_inbound_cidrs)))
+  ]
+}
+
 resource "google_compute_security_policy_rule" "allow_cidrs" {
+  for_each        = { for idx, cidrs in local.cidrs_chunked : idx => cidrs }
   security_policy = google_compute_security_policy.default.name
-  description     = "Allowed CIDRs"
-  priority        = 1001
+  description     = "Allowed CIDRs chunk ${each.key + 1}"
+  priority        = 1001 + each.key
   match {
     versioned_expr = "SRC_IPS_V1"
     config {
-      src_ip_ranges = var.allowed_inbound_cidrs
+      src_ip_ranges = each.value
     }
   }
   action = "allow"


### PR DESCRIPTION
ref: INFRA-392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the handling of inbound security rules by dynamically grouping allowed IP ranges into smaller sets, enabling more granular rule management and prioritized application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->