### PR TITLE
fix: Bump k8s max nodes by 1

### DIFF
--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -4,35 +4,35 @@ locals {
     small = {
       db             = "db-n1-highmem-2",
       min_node_count = 2,
-      max_node_count = 3,
+      max_node_count = 4,
       node_instance  = "n2-highmem-4"
       cache          = "6"
     },
     medium = {
       db             = "db-n1-highmem-4",
       min_node_count = 2,
-      max_node_count = 4,
+      max_node_count = 5,
       node_instance  = "n2-highmem-4"
       cache          = "6"
     },
     large = {
       db             = "db-n1-highmem-8",
       min_node_count = 3,
-      max_node_count = 4,
+      max_node_count = 5,
       node_instance  = "n2-highmem-8"
       cache          = "13"
     },
     xlarge = {
       db             = "db-n1-highmem-16",
       min_node_count = 3,
-      max_node_count = 5,
+      max_node_count = 6,
       node_instance  = "n2-highmem-8"
       cache          = "13"
     },
     xxlarge = {
       db             = "db-n1-highmem-32",
       min_node_count = 3,
-      max_node_count = 6,
+      max_node_count = 7,
       node_instance  = "n2-highmem-16"
       cache          = "26"
     }

--- a/main.tf
+++ b/main.tf
@@ -136,7 +136,7 @@ module "app_gke" {
   depends_on                 = [module.project_factory_project_services]
   max_node_count             = local.max_node_count
   min_node_count             = local.min_node_count
-  labels                     = merge(var.labels, {cache_size = var.cache_size})
+  labels                     = merge(var.labels, { cache_size = var.cache_size })
   enable_private_gke_nodes   = var.enable_private_gke_nodes
 }
 


### PR DESCRIPTION
The max k8s nodes setting is controlled in `deployment-size.tf` and is not defaulted in `core/../{aws,azure,google}/*.tf` nor `terraform-{aws,google,azurerm}-wandb/{main,variables}.tf`.

Recent platform incidents demonstrated that mass-pod replacement may fail for max node counts < 4.