### PR TITLE
Aravind/enable bufstream

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -245,6 +245,19 @@ module "clickhouse" {
   labels = var.labels
 }
 
+module "bufstream" {
+  count  = var.bufstream.enabled ? 1 : 0
+  source = "./modules/bufstream"
+
+  namespace                 = var.namespace
+  region                    = data.google_client_config.current.region
+  project_id                = local.project_id
+  cluster_name              = "${var.namespace}-cluster"
+  bufstream_namespace       = var.bufstream.namespace
+  bufstream_service_account = var.bufstream.service_account
+  labels                    = var.labels
+}
+
 locals {
   redis_certificate       = var.create_redis ? module.redis[0].ca_cert : null
   redis_connection_string = var.create_redis ? "redis://:${module.redis[0].auth_string}@${module.redis[0].connection_string}?tls=true&ttlInSeconds=604800&caCertPath=/etc/ssl/certs/server_ca.pem" : null

--- a/main.tf
+++ b/main.tf
@@ -249,13 +249,13 @@ module "bufstream" {
   count  = var.bufstream.enabled ? 1 : 0
   source = "./modules/bufstream"
 
-  namespace                 = var.namespace
-  region                    = data.google_client_config.current.region
-  project_id                = local.project_id
-  cluster_name              = "${var.namespace}-cluster"
-  bufstream_namespace       = var.bufstream.namespace
-  bufstream_service_account = var.bufstream.service_account
-  labels                    = var.labels
+  namespace           = var.namespace
+  region              = data.google_client_config.current.region
+  project_id          = local.project_id
+  cluster_name        = "${var.namespace}-cluster"
+  k8s_namespace       = var.bufstream.namespace
+  k8s_service_account = var.bufstream.service_account
+  labels              = var.labels
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -252,7 +252,7 @@ module "bufstream" {
   namespace           = var.namespace
   region              = data.google_client_config.current.region
   project_id          = local.project_id
-  cluster_name        = "${var.namespace}-cluster"
+  cluster_name        = module.app_gke.cluster_name
   k8s_namespace       = var.bufstream.namespace
   k8s_service_account = var.bufstream.service_account
   labels              = var.labels

--- a/modules/bufstream/main.tf
+++ b/modules/bufstream/main.tf
@@ -21,7 +21,7 @@ resource "google_service_account" "bufstream" {
 resource "google_service_account_iam_member" "bufstream_workload_identity" {
   service_account_id = google_service_account.bufstream.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.bufstream_namespace}/${var.bufstream_service_account}]"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.k8s_namespace}/${var.k8s_service_account}]"
 }
 
 resource "google_storage_bucket_iam_member" "bufstream_bucket_admin" {

--- a/modules/bufstream/main.tf
+++ b/modules/bufstream/main.tf
@@ -1,0 +1,31 @@
+resource "google_storage_bucket" "bufstream" {
+  name          = "${substr(var.namespace, 0, 20)}-bufstream"
+  location      = var.region
+  force_destroy = true
+
+  uniform_bucket_level_access = true
+
+  labels = merge(var.labels, {
+    role          = "bufstream-bucket"
+    "customer-ns" = replace(var.namespace, "-cluster", "")
+    cluster       = var.cluster_name
+  })
+}
+
+resource "google_service_account" "bufstream" {
+  account_id   = "${substr(var.namespace, 0, 20)}-bufstream"
+  display_name = "Bufstream Service Account"
+  project      = var.project_id
+}
+
+resource "google_service_account_iam_member" "bufstream_workload_identity" {
+  service_account_id = google_service_account.bufstream.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.bufstream_namespace}/${var.bufstream_service_account}]"
+}
+
+resource "google_storage_bucket_iam_member" "bufstream_bucket_admin" {
+  bucket = google_storage_bucket.bufstream.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.bufstream.email}"
+}

--- a/modules/bufstream/outputs.tf
+++ b/modules/bufstream/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "The name of the Bufstream storage bucket"
+  value       = google_storage_bucket.bufstream.name
+}
+
+output "service_account_email" {
+  description = "The email of the Bufstream service account"
+  value       = google_service_account.bufstream.email
+}

--- a/modules/bufstream/variables.tf
+++ b/modules/bufstream/variables.tf
@@ -1,0 +1,35 @@
+variable "namespace" {
+  type        = string
+  description = "The namespace for the bufstream resources"
+}
+
+variable "region" {
+  type        = string
+  description = "The region for the bufstream bucket"
+}
+
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The cluster name for labeling"
+}
+
+variable "bufstream_namespace" {
+  type        = string
+  description = "The Kubernetes namespace where Bufstream will run"
+}
+
+variable "bufstream_service_account" {
+  type        = string
+  description = "The Kubernetes service account name for Bufstream"
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels to apply to resources"
+  default     = {}
+}

--- a/modules/bufstream/variables.tf
+++ b/modules/bufstream/variables.tf
@@ -18,12 +18,12 @@ variable "cluster_name" {
   description = "The cluster name for labeling"
 }
 
-variable "bufstream_namespace" {
+variable "k8s_namespace" {
   type        = string
   description = "The Kubernetes namespace where Bufstream will run"
 }
 
-variable "bufstream_service_account" {
+variable "k8s_service_account" {
   type        = string
   description = "The Kubernetes service account name for Bufstream"
 }

--- a/modules/bufstream/variables.tf
+++ b/modules/bufstream/variables.tf
@@ -15,7 +15,7 @@ variable "project_id" {
 
 variable "cluster_name" {
   type        = string
-  description = "The cluster name for labeling"
+  description = "The GKE cluster name for labeling"
 }
 
 variable "k8s_namespace" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -118,3 +118,13 @@ output "wandb_spec" {
   value     = local.spec
   sensitive = true
 }
+
+output "bufstream_bucket_name" {
+  description = "The name of the Bufstream storage bucket"
+  value       = var.bufstream.enabled ? module.bufstream[0].bucket_name : null
+}
+
+output "bufstream_service_account_email" {
+  description = "The email of the Bufstream service account"
+  value       = var.bufstream.enabled ? module.bufstream[0].service_account_email : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -264,6 +264,22 @@ variable "create_pubsub" {
 }
 
 ##########################################
+# Bufstream
+##########################################
+
+variable "bufstream" {
+  type = object({
+    enabled         = bool
+    namespace       = optional(string, "bufstream")
+    service_account = optional(string, "bufstream-service-account")
+  })
+  description = "Configuration for Bufstream storage and service account. When enabled, provisions a GCS bucket and service account with workload identity for Bufstream."
+  default = {
+    enabled = false
+  }
+}
+
+##########################################
 # Redis                                  #
 ##########################################
 variable "create_redis" {


### PR DESCRIPTION
Add support for provisioning GCS bucket and service account for Bufstream.

When enabled via the `bufstream` variable, creates:
- GCS bucket for Bufstream storage
- Service account with workload identity binding
- Storage object admin IAM permissions

The bufstream variable accepts optional namespace and service account name configuration, defaulting the "bufstream" namespace.