### PR TITLE
Migrate PR test handler to keyless GitHub OIDC (SECENG-2427)

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -7,12 +7,18 @@ on:
 
 env:
   GOOGLE_SERVICE_ACCOUNT: "terraform-google-testing@playground-111.iam.gserviceaccount.com"
+  # SECENG-2427: GitHub OIDC WIF provider in playground-111. Prerequisite, see PR body.
+  GCP_WORKLOAD_IDENTITY_PROVIDER: "projects/27586067691/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
   TF_TOKEN_app_terraform_io: ${{ secrets.TFE_TOKEN }}
 
 jobs:
   public-dns-with-cloud-dns:
     name: Public DNS with Cloud DNS
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     defaults:
       run:
@@ -58,7 +64,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: "${{ secrets.GOOGLE_TESTING_SA_CREDENTIALS }}"
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GOOGLE_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
## TL;DR

The `/test` PR handler authenticates to GCP with a static JSON service-account key stored in the `GOOGLE_TESTING_SA_CREDENTIALS` repo secret. This swaps that key for keyless GitHub OIDC against `terraform-google-testing@playground-111`, removing the last static GCP key in this workflow.

**Files to review (1, +8 / -1):**

| File | Why |
|---|---|
| `.github/workflows/handler-test.yml` *(start here)* | Adds `id-token: write` / `contents: read` to the `public-dns-with-cloud-dns` job and replaces `credentials_json` with `workload_identity_provider` + `service_account` on `google-github-actions/auth@v2`. |

## Why

Keyless OIDC means no long-lived credential to leak or rotate.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD authentication security by implementing Google OIDC Workload Identity Federation for improved credential management in the build workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wandb/terraform-google-wandb/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->