### PR TITLE
chore(security): enable Renovate for GitHub Actions SHA pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>wandb/renovate-config"]
+}


### PR DESCRIPTION
## Summary

This opts the repo into the centralized WandB Renovate setup for GitHub Actions SHA pinning.

- Adds `.github/renovate.json5` extending `github>wandb/renovate-config`
- No workflow file is added; Renovate runs centrally from `wandb/renovate-config`

## Why

The shared Renovate config enables SHA pinning for GitHub Actions `uses:` references. After this merges and the centralized Renovate workflow runs, Renovate should open a follow-up PR pinning this repo's GitHub Actions to commit SHAs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dependency update configuration to keep project dependencies current with shared Renovate settings.
  * Included the official schema reference for better validation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->